### PR TITLE
[BOOST-4747] fix(evm): check claims against allowlist in BoostCore

### DIFF
--- a/examples/zora-mint/src/zora-mint.test.ts
+++ b/examples/zora-mint/src/zora-mint.test.ts
@@ -124,7 +124,7 @@ describe("Boost with NFT Minting Incentive", () => {
       }),
       allowList: core.SimpleAllowList({
         owner: owner,
-        allowed: [owner],
+        allowed: [owner, boostImpostor],
       }),
       incentives: [
         core.ERC20Incentive({

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -181,6 +181,8 @@ contract BoostCore is Ownable, ReentrancyGuard {
         if (msg.value < claimFee) revert BoostError.InsufficientFunds(address(0), msg.value, claimFee);
         _routeClaimFee(boost, referrer_);
 
+        if (!boost.allowList.isAllowed(claimant, data_)) revert BoostError.Unauthorized();
+
         // wake-disable-next-line reentrancy (false positive, function is nonReentrant)
         if (!boost.validator.validate(boostId_, incentiveId_, claimant, data_)) revert BoostError.Unauthorized();
         if (!boost.incentives[incentiveId_].claim(claimant, data_)) {


### PR DESCRIPTION
Allowlists were only checked in the AllowList incentives, but this
change enforces allowlists for all claims. E2E tests have been added to
validate enforcement and also ensure that no tests pass because of some
other authentication failure.
