### PR TITLE
[BOOST-4797] feat(action-step): handle data fetching at action step level

### DIFF
--- a/.changeset/nasty-planes-remain.md
+++ b/.changeset/nasty-planes-remain.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+moves data fetching for validation at action step level

--- a/examples/zora-mint/src/zora-mint.test.ts
+++ b/examples/zora-mint/src/zora-mint.test.ts
@@ -150,16 +150,17 @@ describe("Boost with NFT Minting Incentive", () => {
       address: boostImpostor,
       value: parseEther("10"),
     });
-    const testReceipt = await walletClient.sendTransaction({
+    const txHash = await walletClient.sendTransaction({
       data: inputData,
       account: boostImpostor,
       to: targetContract,
       value: parseEther("0.029777"),
     });
+    const chainId = await walletClient.getChainId();
 
     // Make sure that the transaction was sent as expected and validates the action
-    expect(testReceipt).toBeDefined();
-    const validation = await action.validateActionSteps();
+    expect(txHash).toBeDefined();
+    const validation = await action.validateActionSteps({ hash: txHash, chainId });
     expect(validation).toBe(true);
     // Generate the signature using the trusted signer
     const claimDataPayload = await boost.validator.encodeClaimData({

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -17,7 +17,6 @@ import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import type { MockERC20 } from '@boostxyz/test/MockERC20';
 import type { MockERC721 } from '@boostxyz/test/MockERC721';
 import { accounts } from '@boostxyz/test/accounts';
-import { InvalidNumericalCriteriaError, FieldValueNotComparableError, UnrecognizedFilterTypeError, ValidationHashMissingError, ValidationChainIdMissingError } from '../errors';
 import {
   type Fixtures,
   type StringEmitterFixtures,
@@ -35,7 +34,6 @@ import {
   PrimitiveType,
   SignatureType,
   Criteria,
-  ValidateActionStepParams,
 } from "./EventAction";
 
 let fixtures: Fixtures,
@@ -393,35 +391,6 @@ describe("EventAction Event Selector", () => {
       });
     });
 
-    test("throws ValidationHashMissingError when hash is missing", async () => {
-      const action = await loadFixture(cloneEventAction(fixtures, erc721));
-      const actionSteps = await action.getActionSteps();
-      try {
-        await action.isActionStepValid(actionSteps[0]!, {} as ValidateActionStepParams);
-      } catch (e) {
-        expect(e).toBeInstanceOf(ValidationHashMissingError);
-        expect((e as ValidationHashMissingError).message).toBe(
-          "Hash is required for validation",
-        );
-      }
-    });
-
-    test("throws ValidationChainIdMissingError when chain id is missing", async () => {
-      const action = await loadFixture(cloneEventAction(fixtures, erc721));
-      const actionSteps = await action.getActionSteps();
-      const recipient = accounts[1].account;
-      await erc721.approve(recipient, 1n);
-      const { hash } = await erc721.transferFromRaw(defaultOptions.account.address, recipient, 1n);
-      try {
-        await action.isActionStepValid(actionSteps[0]!, { hash } as ValidateActionStepParams);
-      } catch (e) {
-        expect(e).toBeInstanceOf(ValidationChainIdMissingError);
-        expect((e as ValidationChainIdMissingError).message).toBe(
-          "Chain id is required for validation",
-        );
-      }
-    });
-
     test("with a correct log, validates", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const recipient = accounts[1].account;
@@ -664,37 +633,6 @@ describe("EventAction Func Selector", () => {
     expect(
       await action.isActionStepValid(actionStep, { hash, chainId })
     ).toBe(true);
-  });
-
-  test("throws ValidationHashMissingError when hash is missing", async () => {
-    const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
-    const actionSteps = await action.getActionSteps();
-    try {
-      await action.isActionStepValid(actionSteps[0]!, {} as ValidateActionStepParams);
-    } catch (e) {
-      expect(e).toBeInstanceOf(ValidationHashMissingError);
-      expect((e as ValidationHashMissingError).message).toBe(
-        "Hash is required for validation",
-      );
-    }
-  });
-
-  test("throws ValidationChainIdMissingError when chain id is missing", async () => {
-    const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
-    const actionSteps = await action.getActionSteps();
-    const actionStep = actionSteps[0]!
-    const recipient = accounts[1].account;
-    const { hash } = await erc721.mintRaw(recipient, {
-      value: parseEther(".1"),
-    });
-    try {
-      await action.isActionStepValid(actionStep, { hash } as ValidateActionStepParams);
-    } catch (e) {
-      expect(e).toBeInstanceOf(ValidationChainIdMissingError);
-      expect((e as ValidationChainIdMissingError).message).toBe(
-        "Chain id is required for validation",
-      );
-    }
   });
 
   test("validates function step with EQUAL filter", async () => {

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -41,10 +41,12 @@ let fixtures: Fixtures,
   erc721: MockERC721,
   erc20: MockERC20,
   stringEmitterFixtures: StringEmitterFixtures;
+let chainId: number;
 
 beforeAll(async () => {
   fixtures = await loadFixture(deployFixtures(defaultOptions));
   stringEmitterFixtures = await loadFixture(deployStringEmitterMock);
+  chainId = defaultOptions.config.chains[0].id;
 });
 
 function basicErc721TransferAction(
@@ -58,7 +60,7 @@ function basicErc721TransferAction(
       ] as Hex,
       fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
-      chainid: defaultOptions.config.chains[0].id,
+      chainid: chainId,
     },
     actionSteps: [
       {
@@ -67,7 +69,7 @@ function basicErc721TransferAction(
         ] as Hex,
         signatureType: SignatureType.EVENT,
         targetContract: erc721.assertValidAddress(),
-        chainid: defaultOptions.config.chains[0].id,
+        chainid: chainId,
         actionParameter: {
           filterType: FilterType.EQUAL,
           fieldType: PrimitiveType.ADDRESS,
@@ -91,14 +93,13 @@ function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
 function basicErc721MintFuncAction(
   erc721: MockERC721,
 ): EventActionPayloadSimple {
-  console.log(funcSelectors["mint(address)"] as Hex);
   return {
     actionClaimant: {
       signatureType: SignatureType.FUNC,
       signature: funcSelectors["mint(address)"] as Hex,
       fieldIndex: 0,
       targetContract: erc721.assertValidAddress(),
-      chainid: defaultOptions.config.chains[0].id,
+      chainid: chainId,
     },
     actionSteps: [
       {
@@ -106,7 +107,7 @@ function basicErc721MintFuncAction(
         signatureType: SignatureType.FUNC,
         actionType: 0,
         targetContract: erc721.assertValidAddress(),
-        chainid: defaultOptions.config.chains[0].id,
+        chainid: chainId,
         actionParameter: {
           filterType: FilterType.EQUAL,
           fieldType: PrimitiveType.ADDRESS,
@@ -125,7 +126,7 @@ function basicErc20MintFuncAction(erc20: MockERC20): EventActionPayloadSimple {
       signature: funcSelectors["mint(address to, uint256 amount)"] as Hex,
       fieldIndex: 0,
       targetContract: erc20.assertValidAddress(),
-      chainid: defaultOptions.config.chains[0].id,
+      chainid: chainId,
     },
     actionSteps: [
       {
@@ -133,7 +134,7 @@ function basicErc20MintFuncAction(erc20: MockERC20): EventActionPayloadSimple {
         signatureType: SignatureType.FUNC,
         actionType: 0,
         targetContract: erc20.assertValidAddress(),
-        chainid: defaultOptions.config.chains[0].id,
+        chainid: chainId,
         actionParameter: {
           filterType: FilterType.EQUAL,
           fieldType: PrimitiveType.ADDRESS,
@@ -159,7 +160,7 @@ function indexedStringErc721TransferAction(
       ] as Hex,
       fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
-      chainid: defaultOptions.config.chains[0].id,
+      chainid: chainId,
     },
     actionSteps: [
       {
@@ -169,7 +170,7 @@ function indexedStringErc721TransferAction(
         signatureType: SignatureType.EVENT,
         actionType: 0,
         targetContract: stringEmitterAddress,
-        chainid: defaultOptions.config.chains[0].id,
+        chainid: chainId,
         actionParameter: {
           filterType,
           fieldType: PrimitiveType.STRING,
@@ -195,7 +196,7 @@ function stringErc721TransferAction(
       ] as Hex,
       fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
-      chainid: defaultOptions.config.chains[0].id,
+      chainid: chainId,
     },
     actionSteps: [
       {
@@ -203,7 +204,7 @@ function stringErc721TransferAction(
         signatureType: SignatureType.EVENT,
         actionType: 0,
         targetContract: stringEmitterAddress,
-        chainid: defaultOptions.config.chains[0].id,
+        chainid: chainId,
         actionParameter: {
           filterType,
           fieldType: PrimitiveType.STRING,
@@ -308,7 +309,7 @@ describe("EventAction Event Selector", () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const steps = await action.getActionSteps();
       expect(steps.length).toBe(1);
-      const step = steps[0];
+      const step = steps[0]!;
       step.targetContract = step.targetContract.toUpperCase() as Hex;
       step.actionParameter.filterData =
         step.actionParameter.filterData.toUpperCase() as Hex;
@@ -351,7 +352,7 @@ describe("EventAction Event Selector", () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const steps = await action.getActionSteps();
       expect(steps.length).toBe(1);
-      const step = steps[0];
+      const step = steps[0]!;
       step.targetContract = step.targetContract.toUpperCase() as Hex;
       step.actionParameter.filterData =
         step.actionParameter.filterData.toUpperCase() as Hex;
@@ -391,20 +392,29 @@ describe("EventAction Event Selector", () => {
       });
     });
 
-    test("with no logs, does not validate", async () => {
+    test("throws an error when hash is missing", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
-      expect(await action.validateActionSteps()).toBe(false);
+      const actionSteps = await action.getActionSteps();
+      try {
+        await action.isActionStepValid(actionSteps[0]!, {} as unknown as any);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Hash is required for event validation",
+        );
+      }
     });
 
     test("with a correct log, validates", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const recipient = accounts[1].account;
       await erc721.approve(recipient, 1n);
-      await erc721.transferFrom(defaultOptions.account.address, recipient, 1n);
-      expect(await action.validateActionSteps()).toBe(true);
+      const { hash } = await erc721.transferFromRaw(defaultOptions.account.address, recipient, 1n);
+      expect(await action.validateActionSteps({ hash, chainId })).toBe(true);
     });
 
     test("can supply your own logs to validate against", async () => {
+      const hash = "0xff0e6ab0c4961ec14b7b40afec83ed7d7a77582683512a262e641d21f82efea5"
       const logs: EventLogs = [
         {
           eventName: "Transfer",
@@ -432,7 +442,7 @@ describe("EventAction Event Selector", () => {
         },
       ];
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
-      expect(await action.validateActionSteps({ logs })).toBe(true);
+      expect(await action.validateActionSteps({ hash, chainId, logs })).toBe(true);
     });
 
     describe("string event actions", () => {
@@ -449,8 +459,8 @@ describe("EventAction Event Selector", () => {
           ),
         );
 
-        await stringEmitterFixtures.emitIndexedString("Hello world");
-        await expect(() => action.validateActionSteps()).rejects.toThrowError(
+        const hash = await stringEmitterFixtures.emitIndexedString("Hello world");
+        await expect(() => action.validateActionSteps({ hash, chainId })).rejects.toThrowError(
           /Parameter is not transparently stored onchain/,
         );
       });
@@ -466,8 +476,8 @@ describe("EventAction Event Selector", () => {
             ),
           ),
         );
-        await stringEmitterFixtures.emitString("Hello world");
-        expect(await action.validateActionSteps()).toBe(true);
+        const hash = await stringEmitterFixtures.emitString("Hello world");
+        expect(await action.validateActionSteps({ hash, chainId })).toBe(true);
       });
       test("can parse and validate regex for an emitted string event", async () => {
         const action = await loadFixture(
@@ -482,8 +492,8 @@ describe("EventAction Event Selector", () => {
           ),
         );
 
-        await stringEmitterFixtures.emitString("Hello world");
-        expect(await action.validateActionSteps()).toBe(true);
+        const hash = await stringEmitterFixtures.emitString("Hello world");
+        expect(await action.validateActionSteps({ hash, chainId })).toBe(true);
       });
     });
   });
@@ -628,15 +638,14 @@ describe("EventAction Func Selector", () => {
   test("validates function action step with correct hash", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
+    const actionStep = actionSteps[0]!
     const recipient = accounts[1].account;
     const { hash } = await erc721.mintRaw(recipient, {
       value: parseEther(".1"),
     });
 
     expect(
-      await action.isActionFunctionValid(actionSteps[0], {
-        hash,
-      }),
+      await action.isActionStepValid(actionStep, { hash, chainId })
     ).toBe(true);
   });
 
@@ -644,7 +653,7 @@ describe("EventAction Func Selector", () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
     try {
-      await action.isActionFunctionValid(actionSteps[0], {});
+      await action.isActionStepValid(actionSteps[0]!, {} as unknown as any);
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
       expect((e as Error).message).toBe(
@@ -656,14 +665,15 @@ describe("EventAction Func Selector", () => {
   test("validates function step with EQUAL filter", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
-
+    const actionStep = actionSteps[0]!
     const recipient = accounts[1].account;
     const { hash } = await erc721.mintRaw(recipient, {
       value: parseEther(".1"),
     });
 
-    const criteriaMatch = await action.isActionFunctionValid(actionSteps[0], {
+    const criteriaMatch = await action.isActionStepValid(actionStep, {
       hash,
+      chainId,
     });
 
     expect(criteriaMatch).toBe(true);
@@ -672,10 +682,11 @@ describe("EventAction Func Selector", () => {
   test("fails validation with incorrect function signature", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
+    const actionStep = actionSteps[0]!;
     const recipient = accounts[1].account;
 
     const invalidStep = {
-      ...actionSteps[0],
+      ...actionStep,
       signature: funcSelectors["mint(address to, uint256 amount)"] as Hex, // Intentional mismatch
     };
 
@@ -684,7 +695,7 @@ describe("EventAction Func Selector", () => {
     });
 
     try {
-      await action.isActionFunctionValid(invalidStep, { hash });
+      await action.isActionStepValid(invalidStep, { hash, chainId });
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
       expect((e as Error).message).toContain(
@@ -696,15 +707,17 @@ describe("EventAction Func Selector", () => {
   test("validates against NOT_EQUAL filter criteria", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
-    actionSteps[0].actionParameter.filterType = FilterType.NOT_EQUAL;
+    const actionStep = actionSteps[0]!;
+    actionStep.actionParameter.filterType = FilterType.NOT_EQUAL;
     const recipient = accounts[2].account;
     const { hash } = await erc721.mintRaw(recipient, {
       value: parseEther(".1"),
     });
 
     expect(
-      await action.isActionFunctionValid(actionSteps[0], {
+      await action.isActionStepValid(actionStep, {
         hash,
+        chainId,
       }),
     ).toBe(true);
   });
@@ -712,8 +725,9 @@ describe("EventAction Func Selector", () => {
   test("validates GREATER_THAN criteria for numeric values", async () => {
     const action = await loadFixture(cloneFunctionAction20(fixtures, erc20));
     const actionSteps = await action.getActionSteps();
+    const actionStep = actionSteps[0]!;
 
-    actionSteps[0].actionParameter = {
+    actionStep.actionParameter = {
       filterType: FilterType.GREATER_THAN,
       fieldType: PrimitiveType.UINT,
       fieldIndex: 1,
@@ -725,8 +739,9 @@ describe("EventAction Func Selector", () => {
     const { hash } = await erc20.mintRaw(address, value);
 
     expect(
-      await action.isActionFunctionValid(actionSteps[0], {
+      await action.isActionStepValid(actionStep, {
         hash,
+        chainId,
       }),
     ).toBe(true);
   });
@@ -734,7 +749,8 @@ describe("EventAction Func Selector", () => {
   test("validates LESS_THAN criteria for numeric values", async () => {
     const action = await loadFixture(cloneFunctionAction20(fixtures, erc20));
     const actionSteps = await action.getActionSteps();
-    actionSteps[0].actionParameter = {
+    const actionStep = actionSteps[0]!;
+    actionStep.actionParameter = {
       filterType: FilterType.LESS_THAN,
       fieldType: PrimitiveType.UINT,
       fieldIndex: 1,
@@ -746,8 +762,9 @@ describe("EventAction Func Selector", () => {
     const { hash } = await erc20.mintRaw(address, value);
 
     expect(
-      await action.isActionFunctionValid(actionSteps[0], {
+      await action.isActionStepValid(actionStep, {
         hash,
+        chainId,
       }),
     ).toBe(true);
   });
@@ -762,6 +779,7 @@ describe("EventAction Func Selector", () => {
     expect(
       await action.validateActionSteps({
         hash,
+        chainId,
       }),
     ).toBe(true);
   });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -35,6 +35,7 @@ import {
   PrimitiveType,
   SignatureType,
   Criteria,
+  ValidateActionStepParams,
 } from "./EventAction";
 
 let fixtures: Fixtures,
@@ -396,7 +397,7 @@ describe("EventAction Event Selector", () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const actionSteps = await action.getActionSteps();
       try {
-        await action.isActionStepValid(actionSteps[0]!, {} as unknown as any);
+        await action.isActionStepValid(actionSteps[0]!, {} as ValidateActionStepParams);
       } catch (e) {
         expect(e).toBeInstanceOf(ValidationHashMissingError);
         expect((e as ValidationHashMissingError).message).toBe(
@@ -412,7 +413,7 @@ describe("EventAction Event Selector", () => {
       await erc721.approve(recipient, 1n);
       const { hash } = await erc721.transferFromRaw(defaultOptions.account.address, recipient, 1n);
       try {
-        await action.isActionStepValid(actionSteps[0]!, { hash });
+        await action.isActionStepValid(actionSteps[0]!, { hash } as ValidateActionStepParams);
       } catch (e) {
         expect(e).toBeInstanceOf(ValidationChainIdMissingError);
         expect((e as ValidationChainIdMissingError).message).toBe(
@@ -669,7 +670,7 @@ describe("EventAction Func Selector", () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
     try {
-      await action.isActionStepValid(actionSteps[0]!, {} as unknown as any);
+      await action.isActionStepValid(actionSteps[0]!, {} as ValidateActionStepParams);
     } catch (e) {
       expect(e).toBeInstanceOf(ValidationHashMissingError);
       expect((e as ValidationHashMissingError).message).toBe(
@@ -687,7 +688,7 @@ describe("EventAction Func Selector", () => {
       value: parseEther(".1"),
     });
     try {
-      await action.isActionStepValid(actionStep, { hash });
+      await action.isActionStepValid(actionStep, { hash } as ValidateActionStepParams);
     } catch (e) {
       expect(e).toBeInstanceOf(ValidationChainIdMissingError);
       expect((e as ValidationChainIdMissingError).message).toBe(

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -662,6 +662,9 @@ export class EventAction extends DeployableTarget<
    *
    * @param {Criteria} criteria - The criteria to validate against.
    * @param {string | bigint | Hex} fieldValue - The field value to validate.
+   * @param {Object} input - Additional context for validation.
+   * @param {EventLogs[0]} [input.log] - The event log, if validating an event.
+   * @param {readonly (string | bigint)[]} [input.decodedArgs] - The decoded function arguments, if validating a function call.
    * @returns {Promise<boolean>} - Returns true if the field passes the criteria, false otherwise.
    */
   public validateFieldAgainstCriteria(

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -44,6 +44,8 @@ import {
   TooManyEventActionStepsProvidedError,
   UnparseableAbiParamError,
   UnrecognizedFilterTypeError,
+  ValidationChainIdMissingError,
+  ValidationHashMissingError,
 } from '../errors';
 import {
   type GetLogsParams,
@@ -536,10 +538,6 @@ export class EventAction extends DeployableTarget<
     actionStep: ActionStep,
     params: TxParams & { hash?: Hex; chainId?: number },
   ) {
-    const client = this._config.getClient({
-      chainId: params.chainId,
-    }) as PublicClient;
-
     if (actionStep.signatureType === SignatureType.EVENT) {
       const eventParams = params as ValidateEventStepParams;
       const signature = actionStep.signature;
@@ -573,12 +571,15 @@ export class EventAction extends DeployableTarget<
       }
 
       if (!params?.hash) {
-        throw new Error('Hash is required for event validation');
+        throw new ValidationHashMissingError();
       }
       if (!params?.chainId) {
-        throw new Error('Chain id is required for event validation');
+        throw new ValidationChainIdMissingError();
       }
 
+      const client = this._config.getClient({
+        chainId: params.chainId,
+      }) as PublicClient;
       const receipt = await client.getTransactionReceipt({
         hash: params.hash,
       });
@@ -599,11 +600,14 @@ export class EventAction extends DeployableTarget<
     }
     if (actionStep.signatureType === SignatureType.FUNC) {
       if (!params?.hash) {
-        throw new Error('Hash is required for function validation');
+        throw new ValidationHashMissingError();
       }
       if (!params?.chainId) {
-        throw new Error('Chain id is required for function validation');
+        throw new ValidationChainIdMissingError();
       }
+      const client = this._config.getClient({
+        chainId: params.chainId,
+      }) as PublicClient;
       const transaction = await client.getTransaction({
         hash: params.hash,
       });

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -45,8 +45,6 @@ import {
   UnparseableAbiParamError,
   UnrecognizedFilterTypeError,
   ValidationAbiMissingError,
-  ValidationChainIdMissingError,
-  ValidationHashMissingError,
   ValidationLogsMissingError,
 } from '../errors';
 import {
@@ -546,10 +544,6 @@ export class EventAction extends DeployableTarget<
         return this.isActionEventValid(actionStep, {
           ...params,
         });
-      } else if (!('hash' in params)) {
-        throw new ValidationHashMissingError();
-      } else if (!('chainId' in params)) {
-        throw new ValidationChainIdMissingError();
       }
 
       const client = this._config.getClient({
@@ -582,10 +576,6 @@ export class EventAction extends DeployableTarget<
           hash: params.hash,
         });
         return this.isActionFunctionValid(actionStep, transaction);
-      } else if (!('hash' in params)) {
-        throw new ValidationHashMissingError();
-      } else if (!('chainId' in params)) {
-        throw new ValidationChainIdMissingError();
       }
     }
     return false;

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -422,44 +422,6 @@ export class TooManyEventActionStepsProvidedError extends Error {
 }
 
 /**
- * Thrown when missing a transaction hash for validating action steps.
- *
- * @export
- * @class ValidationHashMissingError
- * @typedef {ValidationHashMissingError}
- * @extends {Error}
- */
-export class ValidationHashMissingError extends Error {
-  /**
-   * Creates an instance of ValidationHashMissingError.
-   *
-   * @constructor
-   */
-  constructor() {
-    super('Hash is required for validation');
-  }
-}
-
-/**
- * Thrown when missing a chain id for validating action steps.
- *
- * @export
- * @class ValidationChainIdMissingError
- * @typedef {ValidationChainIdMissingError}
- * @extends {Error}
- */
-export class ValidationChainIdMissingError extends Error {
-  /**
-   * Creates an instance of ValidationChainIdMissingError.
-   *
-   * @constructor
-   */
-  constructor() {
-    super('Chain id is required for validation');
-  }
-}
-
-/**
  * The error is thrown when trying to reuse an existing deployed Incentive that isn't a base implementation.
  *
  * @export

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -460,6 +460,45 @@ export class ValidationChainIdMissingError extends Error {
 }
 
 /**
+ * The error is thrown when trying to reuse an existing deployed Incentive that isn't a base implementation.
+ *
+ * @export
+ * @class ValidationAbiMissingError
+ * @typedef {ValidationAbiMissingError}
+ * @extends {Error}
+ */
+export class ValidationAbiMissingError extends Error {
+  /**
+   * Creates an instance of ValidationAbiMissingError.
+   *
+   * @constructor
+   * @param {Hex} signature
+   */
+  constructor(signature: Hex) {
+    super(`No known ABI for given signature: ${signature}`);
+  }
+}
+
+/**
+ * Thrown when missing logs for validating action steps.
+ *
+ * @export
+ * @class ValidationLogsMissingError
+ * @typedef {ValidationLogsMissingError}
+ * @extends {Error}
+ */
+export class ValidationLogsMissingError extends Error {
+  /**
+   * Creates an instance of ValidationLogsMissingError.
+   *
+   * @constructor
+   */
+  constructor() {
+    super('Logs are required for validation');
+  }
+}
+
+/**
  * Function action validation context to help debug other validation errors
  *
  * @interface FunctionActionValidationMeta

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -422,6 +422,44 @@ export class TooManyEventActionStepsProvidedError extends Error {
 }
 
 /**
+ * Thrown when missing a transaction hash for validating action steps.
+ *
+ * @export
+ * @class ValidationHashMissingError
+ * @typedef {ValidationHashMissingError}
+ * @extends {Error}
+ */
+export class ValidationHashMissingError extends Error {
+  /**
+   * Creates an instance of ValidationHashMissingError.
+   *
+   * @constructor
+   */
+  constructor() {
+    super('Hash is required for validation');
+  }
+}
+
+/**
+ * Thrown when missing a chain id for validating action steps.
+ *
+ * @export
+ * @class ValidationChainIdMissingError
+ * @typedef {ValidationChainIdMissingError}
+ * @extends {Error}
+ */
+export class ValidationChainIdMissingError extends Error {
+  /**
+   * Creates an instance of ValidationChainIdMissingError.
+   *
+   * @constructor
+   */
+  constructor() {
+    super('Chain id is required for validation');
+  }
+}
+
+/**
  * Function action validation context to help debug other validation errors
  *
  * @interface FunctionActionValidationMeta


### PR DESCRIPTION
### Description
There are several changes in this PR:
- Uses the tx hash to fetch logs for event validation
- Moves the onchain data fetching from `isActionEventValid` and `isActionFunctionValid` into the parent `isActionStepValid` function
- On event validation, we check against all logs rather than the first match -- this allows us to validate if the tx has multiple logs that are the same (e.g. multiple transfer events on a Uniswap tx)