### PR TITLE
[BOOST-4736] fix(evm): enable multiple claims by an address for ERC1155Incentives

### DIFF
--- a/packages/evm/contracts/incentives/AAllowListIncentive.sol
+++ b/packages/evm/contracts/incentives/AAllowListIncentive.sol
@@ -19,6 +19,9 @@ abstract contract AAllowListIncentive is AIncentive {
     /// @notice The maximum number of claims that can be made (one per address)
     uint256 public limit;
 
+    /// @notice A mapping of address to claim status
+    mapping(address => bool) public claimed;
+
     /// @inheritdoc ACloneable
     function getComponentInterface() public pure virtual override(ACloneable) returns (bytes4) {
         return type(AAllowListIncentive).interfaceId;

--- a/packages/evm/contracts/incentives/ACGDAIncentive.sol
+++ b/packages/evm/contracts/incentives/ACGDAIncentive.sol
@@ -25,6 +25,9 @@ abstract contract ACGDAIncentive is AIncentive {
         uint256 currentReward;
     }
 
+    /// @notice A mapping of address to claim status
+    mapping(address => bool) public claimed;
+
     /// @notice The ERC20-like token used for the incentive
     address public asset;
 

--- a/packages/evm/contracts/incentives/AERC1155Incentive.sol
+++ b/packages/evm/contracts/incentives/AERC1155Incentive.sol
@@ -21,6 +21,9 @@ abstract contract AERC1155Incentive is AIncentive, IERC1155Receiver {
         MINT
     }
 
+    /// @notice A mapping of txHash to claim status
+    mapping(bytes32 => bool) public claimed;
+
     /// @notice The address of the ERC1155-compliant contract
     IERC1155 public asset;
 

--- a/packages/evm/contracts/incentives/AERC20Incentive.sol
+++ b/packages/evm/contracts/incentives/AERC20Incentive.sol
@@ -28,6 +28,9 @@ abstract contract AERC20Incentive is AIncentive {
         RAFFLE
     }
 
+    /// @notice A mapping of address to claim status
+    mapping(address => bool) public claimed;
+
     /// @notice The address of the ERC20-like token
     address public asset;
 

--- a/packages/evm/contracts/incentives/AERC20VariableIncentive.sol
+++ b/packages/evm/contracts/incentives/AERC20VariableIncentive.sol
@@ -15,6 +15,9 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 abstract contract AERC20VariableIncentive is AIncentive {
     using SafeTransferLib for address;
 
+    /// @notice A mapping of address to claim status
+    mapping(address => bool) public claimed;
+
     /// @notice The address of the ERC20-like token
     address public asset;
 

--- a/packages/evm/contracts/incentives/AIncentive.sol
+++ b/packages/evm/contracts/incentives/AIncentive.sol
@@ -34,9 +34,6 @@ abstract contract AIncentive is IBoostClaim, ACloneable {
     /// @notice The reward amount issued for each claim
     uint256 public reward;
 
-    /// @notice A mapping of address to claim status
-    mapping(address => bool) public claimed;
-
     /// @notice Claim the incentive
     /// @param data_ The data payload for the incentive claim
     /// @return True if the incentive was successfully claimed

--- a/packages/evm/contracts/incentives/APointsIncentive.sol
+++ b/packages/evm/contracts/incentives/APointsIncentive.sol
@@ -14,6 +14,9 @@ import {AIncentive} from "contracts/incentives/AIncentive.sol";
 ///     - The maximum number of claims must not have been reached; and
 ///     - This contract must be authorized to operate the points contract's issuance function
 abstract contract APointsIncentive is AIncentive {
+    /// @notice A mapping of address to claim status
+    mapping(address => bool) public claimed;
+
     /// @notice The address of the points contract
     address public venue;
 

--- a/packages/evm/script/solidity/ComponentInterface.s.sol
+++ b/packages/evm/script/solidity/ComponentInterface.s.sol
@@ -73,7 +73,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceAManagedBudget() internal {
         string memory interfaceId = uint256(
             uint32(type(AManagedBudget).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "AManagedBudget",
             interfaceId
@@ -83,14 +83,14 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceAEventAction() internal {
         string memory interfaceId = uint256(
             uint32(type(AEventAction).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize("AEventAction", interfaceId);
     }
 
     function _getInterfaceAERC20Incentive() internal {
         string memory interfaceId = uint256(
             uint32(type(AERC20Incentive).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "AERC20Incentive",
             interfaceId
@@ -100,20 +100,20 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceACloneable() internal {
         string memory interfaceId = uint256(
             uint32(type(ACloneable).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize("ACloneable", interfaceId);
     }
 
     function _getInterfaceABudget() internal {
         string memory interfaceId = uint256(uint32(type(ABudget).interfaceId))
-            .toMinimalHexString();
+            .toHexString(4);
         componentJson = componentJsonKey.serialize("ABudget", interfaceId);
     }
 
     function _getInterfaceAVestingBudget() internal {
         string memory interfaceId = uint256(
             uint32(type(AVestingBudget).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "AVestingBudget",
             interfaceId
@@ -123,7 +123,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceASignerValidator() internal {
         string memory interfaceId = uint256(
             uint32(type(ASignerValidator).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "ASignerValidator",
             interfaceId
@@ -133,7 +133,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceAAllowListIncentive() internal {
         string memory interfaceId = uint256(
             uint32(type(AAllowListIncentive).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "AAllowListIncentive",
             interfaceId
@@ -143,7 +143,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceACGDAIncentive() internal {
         string memory interfaceId = uint256(
             uint32(type(ACGDAIncentive).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "ACGDAIncentive",
             interfaceId
@@ -153,14 +153,14 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceAIncentive() internal {
         string memory interfaceId = uint256(
             uint32(type(AIncentive).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize("AIncentive", interfaceId);
     }
 
     function _getInterfaceAERC20VariableIncentive() internal {
         string memory interfaceId = uint256(
             uint32(type(AERC20VariableIncentive).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "AERC20VariableIncentive",
             interfaceId
@@ -170,7 +170,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceAPointsIncentive() internal {
         string memory interfaceId = uint256(
             uint32(type(APointsIncentive).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "APointsIncentive",
             interfaceId
@@ -180,7 +180,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceASimpleAllowList() internal {
         string memory interfaceId = uint256(
             uint32(type(ASimpleAllowList).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "ASimpleAllowList",
             interfaceId
@@ -190,7 +190,7 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceASimpleDenyList() internal {
         string memory interfaceId = uint256(
             uint32(type(ASimpleDenyList).interfaceId)
-        ).toMinimalHexString();
+        ).toHexString(4);
         componentJson = componentJsonKey.serialize(
             "ASimpleDenyList",
             interfaceId

--- a/packages/sdk/src/Incentives/Incentive.ts
+++ b/packages/sdk/src/Incentives/Incentive.ts
@@ -48,9 +48,8 @@ export type Incentive =
 export const IncentiveByComponentInterface = {
   [APointsIncentive as Hex]: PointsIncentive,
   [AERC20Incentive as Hex]: ERC20Incentive,
-  // TODO: figure out why evm generates bad bytes4 here
-  ['0x0a466e6f']: AllowListIncentive,
-  // [APointsIncentive as Hex]: ERC1155Incentive,
+  [AAllowListIncentive]: AllowListIncentive,
+  // [AERC1155Incentive as Hex]: ERC1155Incentive,
   [ACGDAIncentive as Hex]: CGDAIncentive,
   [AERC20VariableIncentive as Hex]: ERC20VariableIncentive,
 };


### PR DESCRIPTION
Claimants can claim 1 ERC 1155 per transaction. Transactions are
validated offchain, but to ensure a unique signanature and claim
attempt, transaction hashes are passed in as part of the claim payload
and stored onchain. As a basic validation with `isClaimable`, the same
transaction hash cannot be claimed against, irrespective of the claim
target
