### PR TITLE
[ADHOC] chore(sdk): correct all typedoc return types

### DIFF
--- a/packages/sdk/src/Actions/ContractAction.ts
+++ b/packages/sdk/src/Actions/ContractAction.ts
@@ -116,7 +116,7 @@ export class ContractAction<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof contractActionAbi, 'chainId'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async chainId(
@@ -135,7 +135,7 @@ export class ContractAction<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof contractActionAbi, 'target'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
   public async target(params?: ReadParams<typeof contractActionAbi, 'target'>) {
@@ -153,7 +153,7 @@ export class ContractAction<
    * @example `function mint(address to, uint256 amount)`
    * @public
    * @async
-   * @param {?ReadParams<typeof contractActionAbi, 'selector'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
   public async selector(
@@ -172,7 +172,7 @@ export class ContractAction<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof contractActionAbi, 'value'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async value(params?: ReadParams<typeof contractActionAbi, 'value'>) {
@@ -190,7 +190,7 @@ export class ContractAction<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?WriteParams<typeof contractActionAbi, 'execute'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
   public async execute(
@@ -206,7 +206,7 @@ export class ContractAction<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?WriteParams<typeof contractActionAbi, 'execute'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
   public async executeRaw(
@@ -233,7 +233,7 @@ export class ContractAction<
    * @public
    * @async
    * @param {Hex} calldata
-   * @param {?ReadParams<typeof contractActionAbi, 'prepare'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
   public async prepare(

--- a/packages/sdk/src/Actions/ContractAction.ts
+++ b/packages/sdk/src/Actions/ContractAction.ts
@@ -17,7 +17,6 @@ import {
   encodeAbiParameters,
   parseAbiParameters,
 } from 'viem';
-import {} from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -208,7 +207,7 @@ export class ContractAction<
    * @async
    * @param {Hex} data
    * @param {?WriteParams<typeof contractActionAbi, 'execute'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
   public async executeRaw(
     data: Hex,
@@ -235,7 +234,7 @@ export class ContractAction<
    * @async
    * @param {Hex} calldata
    * @param {?ReadParams<typeof contractActionAbi, 'prepare'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<`0x${string}`>}
    */
   public async prepare(
     calldata: Hex,

--- a/packages/sdk/src/Actions/ERC721MintAction.ts
+++ b/packages/sdk/src/Actions/ERC721MintAction.ts
@@ -15,7 +15,6 @@ import {
   encodeAbiParameters,
   toHex,
 } from 'viem';
-import {} from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -98,7 +97,7 @@ export class ERC721MintAction extends ContractAction<
    * @async
    * @param {bigint} token
    * @param {?ReadParams<typeof erc721MintActionAbi, 'validated'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   public async validated(
     token: bigint,
@@ -120,7 +119,7 @@ export class ERC721MintAction extends ContractAction<
    * @async
    * @param {Hex} data
    * @param {?WriteParams<typeof erc721MintActionAbi, 'execute'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
   public override async execute(
     data: Hex,
@@ -136,7 +135,7 @@ export class ERC721MintAction extends ContractAction<
    * @async
    * @param {Hex} data
    * @param {?WriteParams<typeof erc721MintActionAbi, 'execute'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
   public override async executeRaw(
     data: Hex,
@@ -163,7 +162,7 @@ export class ERC721MintAction extends ContractAction<
    * @async
    * @param {Hex} data
    * @param {?ReadParams<typeof erc721MintActionAbi, 'prepare'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<`0x${string}`>}
    */
   public override async prepare(
     data: Hex,
@@ -186,7 +185,7 @@ export class ERC721MintAction extends ContractAction<
    * @param {Address} holder - The holder
    * @param {BigInt} tokenId - The token ID
    * @param {?WriteParams<typeof erc721MintActionAbi, 'validate'>} [params]
-   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the action has been validated for the user
+   * @returns {Promise<boolean>} - True if the action has been validated for the user
    */
   protected async validate(
     holder: Address,
@@ -280,7 +279,7 @@ export function prepareERC721MintActionValidate(
  * @param {Address} param0.target - The target contract address
  * @param {Hex} param0.selector - The selector for the function to be called
  * @param {bigint} param0.value - The native token value to send with the function call
- * @returns {*}
+ * @returns {Hex}
  */
 export function prepareERC721MintActionPayload({
   chainId,

--- a/packages/sdk/src/Actions/ERC721MintAction.ts
+++ b/packages/sdk/src/Actions/ERC721MintAction.ts
@@ -96,7 +96,7 @@ export class ERC721MintAction extends ContractAction<
    * @public
    * @async
    * @param {bigint} token
-   * @param {?ReadParams<typeof erc721MintActionAbi, 'validated'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async validated(
@@ -118,7 +118,7 @@ export class ERC721MintAction extends ContractAction<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?WriteParams<typeof erc721MintActionAbi, 'execute'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
   public override async execute(
@@ -134,7 +134,7 @@ export class ERC721MintAction extends ContractAction<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?WriteParams<typeof erc721MintActionAbi, 'execute'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
   public override async executeRaw(
@@ -161,7 +161,7 @@ export class ERC721MintAction extends ContractAction<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?ReadParams<typeof erc721MintActionAbi, 'prepare'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
   public override async prepare(
@@ -184,7 +184,7 @@ export class ERC721MintAction extends ContractAction<
    * @async
    * @param {Address} holder - The holder
    * @param {BigInt} tokenId - The token ID
-   * @param {?WriteParams<typeof erc721MintActionAbi, 'validate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the action has been validated for the user
    */
   protected async validate(
@@ -202,7 +202,7 @@ export class ERC721MintAction extends ContractAction<
    * @async
    * @param {Address} holder - The holder
    * @param {BigInt} tokenId - The token ID
-   * @param {?WriteParams<typeof erc721MintActionAbi, 'validate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the action has been validated for the user
    */
   protected async validateRaw(

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -465,7 +465,7 @@ export class EventAction extends DeployableTarget<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?WriteParams<typeof eventActionAbi, 'execute'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
   public async execute(
@@ -481,7 +481,7 @@ export class EventAction extends DeployableTarget<
    * @public
    * @async
    * @param {Hex} data
-   * @param {?WriteParams<typeof eventActionAbi, 'execute'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
   public async executeRaw(

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -482,7 +482,7 @@ export class EventAction extends DeployableTarget<
    * @async
    * @param {Hex} data
    * @param {?WriteParams<typeof eventActionAbi, 'execute'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
   public async executeRaw(
     data: Hex,

--- a/packages/sdk/src/AllowLists/SimpleAllowList.ts
+++ b/packages/sdk/src/AllowLists/SimpleAllowList.ts
@@ -182,7 +182,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The allowed status of each user
    * @param {?ReadParams<typeof simpleAllowListAbi, 'setAllowed'>} [params]
-   * @returns {Promise<void>}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setAllowedRaw(
     addresses: Address[],

--- a/packages/sdk/src/AllowLists/SimpleAllowList.ts
+++ b/packages/sdk/src/AllowLists/SimpleAllowList.ts
@@ -115,7 +115,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof simpleAllowListAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>} - The address of the owner
    */
   public async owner(
@@ -136,7 +136,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {Address} address - The address of the user
-   * @param {?ReadParams<typeof simpleAllowListAbi, 'setAllowed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the user is authorized
    */
   public async isAllowed(
@@ -160,7 +160,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The allowed status of each user
-   * @param {?ReadParams<typeof simpleAllowListAbi, 'setAllowed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<void>}
    */
   public async setAllowed(
@@ -181,7 +181,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The allowed status of each user
-   * @param {?ReadParams<typeof simpleAllowListAbi, 'setAllowed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setAllowedRaw(

--- a/packages/sdk/src/AllowLists/SimpleDenyList.ts
+++ b/packages/sdk/src/AllowLists/SimpleDenyList.ts
@@ -152,7 +152,7 @@ export class SimpleDenyList<
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The denied status of each user
    * @param {?WriteParams<typeof simpleDenyListAbi, 'setDenied'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<void>}
    */
   public async setDenied(
     addresses: Address[],
@@ -172,7 +172,7 @@ export class SimpleDenyList<
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The denied status of each user
    * @param {?WriteParams<typeof simpleDenyListAbi, 'setDenied'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setDeniedRaw(
     addresses: Address[],

--- a/packages/sdk/src/AllowLists/SimpleDenyList.ts
+++ b/packages/sdk/src/AllowLists/SimpleDenyList.ts
@@ -107,7 +107,7 @@ export class SimpleDenyList<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof simpleDenyListAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>} - The address of the owner
    */
   public async owner(
@@ -128,7 +128,7 @@ export class SimpleDenyList<
    * @public
    * @async
    * @param {Address} address - The address of the user
-   * @param {?ReadParams<typeof simpleDenyListAbi, 'isAllowed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the user is authorized
    */
   public async isAllowed(
@@ -151,7 +151,7 @@ export class SimpleDenyList<
    * @async
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The denied status of each user
-   * @param {?WriteParams<typeof simpleDenyListAbi, 'setDenied'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async setDenied(
@@ -171,7 +171,7 @@ export class SimpleDenyList<
    * @async
    * @param {Address[]} addresses - The list of users to update
    * @param {boolean[]} allowed - The denied status of each user
-   * @param {?WriteParams<typeof simpleDenyListAbi, 'setDenied'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setDeniedRaw(

--- a/packages/sdk/src/Boost.ts
+++ b/packages/sdk/src/Boost.ts
@@ -13,6 +13,25 @@ import type { Incentive } from './Incentives/Incentive';
 import type { Validator } from './Validators/Validator';
 
 /**
+ * Interface representing a `BoostLib.Boost` on-chain struct
+ *
+ * @export
+ * @interface BoostPayload
+ * @typedef {BoostPayload}
+ */
+export interface RawBoost {
+  action: Address;
+  validator: Address;
+  allowList: Address;
+  budget: Address;
+  incentives: readonly Address[];
+  protocolFee: bigint;
+  referralFee: bigint;
+  maxParticipants: bigint;
+  owner: Address;
+}
+
+/**
  * Configuration used to instantiate a `Boost` instance.
  *
  * @export

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -48,6 +48,7 @@ import { type Auth, PassthroughAuth } from './Auth/Auth';
 import {
   Boost,
   type BoostPayload,
+  RawBoost,
   type Target,
   prepareBoostPayload,
 } from './Boost';
@@ -303,7 +304,7 @@ export class BoostCore extends Deployable<
    * @async
    * @param {CreateBoostPayload} _boostPayload
    * @param {?DeployableOptions} [_options]
-   * @returns {Boost}
+   * @returns {Promise<Boost>}
    */
   public async createBoost(
     _boostPayload: CreateBoostPayload,
@@ -527,7 +528,7 @@ export class BoostCore extends Deployable<
    * @param {bigint} incentiveId
    * @param {Address} address
    * @param {Hex} data
-   * @param {?WriteParams<typeof boostCoreAbi, 'claimIncentive'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async claimIncentive(
@@ -551,7 +552,7 @@ export class BoostCore extends Deployable<
    * @param {bigint} incentiveId - The ID of the Incentive
    * @param {Address} referrer - The address of the referrer (if any)
    * @param {Hex} data- The data for the claim
-   * @param {?WriteParams<typeof boostCoreAbi, 'claimIncentive'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async claimIncentiveRaw(
@@ -589,8 +590,8 @@ export class BoostCore extends Deployable<
    * @param {Address} referrer
    * @param {Hex} data
    * @param {Address} claimant
-   * @param {?WriteParams<typeof boostCoreAbi, 'claimIncentiveFor'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
    */
   public async claimIncentiveFor(
     boostId: bigint,
@@ -622,8 +623,8 @@ export class BoostCore extends Deployable<
    * @param {Address} referrer - The address of the referrer (if any)
    * @param {Hex} data - The data for the claim
    * @param {Address} claimant - The address of the user eligible for the incentive payout
-   * @param {?WriteParams<typeof boostCoreAbi, 'claimIncentiveFor'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: Hex; result: void; }>}
    */
   public async claimIncentiveForRaw(
     boostId: bigint,
@@ -657,8 +658,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {bigint} id
-   * @param {?ReadParams<typeof boostCoreAbi, 'getBoost'>} [params]
-   * @returns {unknown}
+   * @param {?ReadParams} [params]
+   * @returns {Promise<RawBoost>}
    */
   public async readBoost(
     id: bigint,
@@ -679,8 +680,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {(string | bigint)} _id
-   * @param {?ReadParams<typeof boostCoreAbi, 'getBoost'>} [params]
-   * @returns {unknown}
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Boost>}
    */
   public async getBoost(
     _id: string | bigint,
@@ -732,7 +733,7 @@ export class BoostCore extends Deployable<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof boostCoreAbi, 'getBoostCount'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async getBoostCount(
@@ -757,7 +758,7 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof boostCoreAbi, 'createBoostAuth'> &
+   * @param {?ReadParams &
    *       ReadParams<typeof iAuthAbi, 'isAuthorized'>} [params]
    * @returns {Promise<boolean>}
    */
@@ -781,8 +782,8 @@ export class BoostCore extends Deployable<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof boostCoreAbi, 'createBoostAuth'>} [params]
-   * @returns {unknown}
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>}
    */
   public async createBoostAuth(
     params?: ReadParams<typeof boostCoreAbi, 'createBoostAuth'>,
@@ -806,8 +807,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {Auth} auth
-   * @param {?WriteParams<typeof boostCoreAbi, 'setCreateBoostAuth'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
    */
   public async setCreateBoostAuth(
     auth: Auth,
@@ -826,8 +827,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {Address} address
-   * @param {?WriteParams<typeof boostCoreAbi, 'setCreateBoostAuth'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setCreateBoostAuthRaw(
     address: Address,
@@ -856,7 +857,7 @@ export class BoostCore extends Deployable<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof boostCoreAbi, 'protocolFee'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {unknown}
    */
   public async protocolFee(
@@ -880,8 +881,8 @@ export class BoostCore extends Deployable<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof boostCoreAbi, 'protocolFeeReceiver'>} [params]
-   * @returns {unknown}
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>}
    */
   public async protocolFeeReceiver(
     params?: ReadParams<typeof boostCoreAbi, 'protocolFeeReceiver'>,
@@ -905,8 +906,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {Address} address
-   * @param {?WriteParams<typeof boostCoreAbi, 'setProtocolFeeReceiver'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
    */
   public async setProcolFeeReceiver(
     address: Address,
@@ -925,8 +926,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {Address} address
-   * @param {?WriteParams<typeof boostCoreAbi, 'setProtocolFeeReceiver'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setProcolFeeReceiverRaw(
     address: Address,
@@ -958,8 +959,8 @@ export class BoostCore extends Deployable<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof boostCoreAbi, 'claimFee'>} [params]
-   * @returns {unknown}
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>}
    */
   public async claimFee(params?: ReadParams<typeof boostCoreAbi, 'claimFee'>) {
     return await readBoostCoreClaimFee(this._config, {
@@ -981,8 +982,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {bigint} claimFee
-   * @param {?WriteParams<typeof boostCoreAbi, 'setClaimFee'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
    */
   public async setClaimFee(
     claimFee: bigint,
@@ -997,8 +998,8 @@ export class BoostCore extends Deployable<
    * @public
    * @async
    * @param {bigint} claimFee
-   * @param {?WriteParams<typeof boostCoreAbi, 'setClaimFee'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setClaimFeeRaw(
     claimFee: bigint,

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -528,7 +528,7 @@ export class BoostCore extends Deployable<
    * @param {Address} address
    * @param {Hex} data
    * @param {?WriteParams<typeof boostCoreAbi, 'claimIncentive'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<void>}
    */
   public async claimIncentive(
     boostId: bigint,
@@ -552,7 +552,7 @@ export class BoostCore extends Deployable<
    * @param {Address} referrer - The address of the referrer (if any)
    * @param {Hex} data- The data for the claim
    * @param {?WriteParams<typeof boostCoreAbi, 'claimIncentive'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async claimIncentiveRaw(
     boostId: bigint,

--- a/packages/sdk/src/BoostRegistry.ts
+++ b/packages/sdk/src/BoostRegistry.ts
@@ -214,8 +214,8 @@ export class BoostRegistry extends Deployable<
    * @param {RegistryType} registryType - The base type for the implementation
    * @param {string} name - A name for the implementation (must be unique within the given type)
    * @param {Address} implementation - The address of the implementation contract
-   * @param {?WriteParams<typeof boostRegistryAbi, 'register'>} [params] - Optional params to provide the underlying Viem contract call
-   * @returns {unknown}
+   * @param {?WriteParams} [params] - Optional params to provide the underlying Viem contract call
+   * @returns {Promise<void>}
    * @example
    * ```ts
    * await registry.register(ContractAction.registryType, 'ContractAction', ContractAction.base)
@@ -239,8 +239,8 @@ export class BoostRegistry extends Deployable<
    * @param {RegistryType} registryType
    * @param {string} name
    * @param {Address} implementation
-   * @param {?WriteParams<typeof boostRegistryAbi, 'register'>} [params]
-   * @returns {unknown}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async registerRaw(
     registryType: RegistryType,
@@ -275,8 +275,8 @@ export class BoostRegistry extends Deployable<
    * @template {DeployableTarget} Target
    * @param {string} displayName - The display name for the clone
    * @param {Target} target - An instance of a target contract to clone and initialize
-   * @param {?WriteParams<typeof boostRegistryAbi, 'deployClone'>} [params]
-   * @returns {Target} - The provided instance, but with a new address attached.
+   * @param {?WriteParams} [params]
+   * @returns {Promise<Target>} - The provided instance, but with a new address attached.
    * biome-ignore lint/suspicious/noExplicitAny: any deployable target will suffice
    */
   public initialize<Target extends DeployableTarget<any, any>>(
@@ -295,8 +295,8 @@ export class BoostRegistry extends Deployable<
    * @template {DeployableTarget} Target
    * @param {string} displayName - The display name for the clone
    * @param {Target} target - An instance of a target contract to clone and initialize
-   * @param {?WriteParams<typeof boostRegistryAbi, 'deployClone'>} [params]
-   * @returns {Target} - The provided instance, but with a new address attached.
+   * @param {?WriteParams} [params]
+   * @returns {Promise<Target>} - The provided instance, but with a new address attached.
    * biome-ignore lint/suspicious/noExplicitAny: any deployable target will suffice
    */
   public async clone<Target extends DeployableTarget<any, any>>(
@@ -316,8 +316,8 @@ export class BoostRegistry extends Deployable<
    * @template {DeployableTarget} Target
    * @param {string} displayName
    * @param {Target} target
-   * @param {?WriteParams<typeof boostRegistryAbi, 'deployClone'>} [params]
-   * @returns {Target}
+   * @param {?WriteParams} [params]
+   * @returns {Promise<Address>}
    * biome-ignore lint/suspicious/noExplicitAny: any deployable target will suffice
    */
   public async deployClone<Target extends DeployableTarget<any, any>>(
@@ -336,8 +336,8 @@ export class BoostRegistry extends Deployable<
    * @async
    * @param {string} displayName
    * @param {DeployableTarget} target
-   * @param {?WriteParams<typeof boostRegistryAbi, 'deployClone'>} [params]
-   * @returns {unknown} - The transaction hash
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: Hex, result: Address }>} - The transaction hash
    * biome-ignore lint/suspicious/noExplicitAny: any deployable target will suffice
    */
   public async deployCloneRaw<Target extends DeployableTarget<any, any>>(
@@ -379,8 +379,8 @@ export class BoostRegistry extends Deployable<
    * @public
    * @async
    * @param {Hex} identifier - The unique identifier for the implementation (see {getIdentifier})
-   * @param {?ReadParams<typeof boostRegistryAbi, 'getBaseImplementation'>} [params]
-   * @returns {unknown} - The address of the implementation
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>} - The address of the implementation
    */
   public async getBaseImplementation(
     identifier: Hex,
@@ -405,7 +405,7 @@ export class BoostRegistry extends Deployable<
    * @public
    * @async
    * @param {Hex} identifier - The unique identifier for the deployed clone (see {getCloneIdentifier})
-   * @param {?ReadParams<typeof boostRegistryAbi, 'getClone'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>} - The address of the deployed clone
    */
   public async getClone(
@@ -431,7 +431,7 @@ export class BoostRegistry extends Deployable<
    * @public
    * @async
    * @param {Address} deployer - The address of the deployer
-   * @param {?ReadParams<typeof boostRegistryAbi, 'getClones'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex[]>} - The list of deployed clones for the given deployer
    */
   public async getClones(
@@ -460,7 +460,7 @@ export class BoostRegistry extends Deployable<
    * @param {Address} base - The address of the base implementation
    * @param {Address} deployer - The address of the deployer
    * @param {string} displayName - The display name of the clone
-   * @param {?ReadParams<typeof boostRegistryAbi, 'getCloneIdentifier'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>} - The unique identifier for the clone
    */
   public async getCloneIdentifier(
@@ -490,7 +490,7 @@ export class BoostRegistry extends Deployable<
    * @async
    * @param {RegistryType} registryType - The base type for the implementation
    * @param {string} displayName - The name of the implementation
-   * @param {?ReadParams<typeof boostRegistryAbi, 'getIdentifier'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>} - The unique identifier for the implementation
    */
   public async getIdentifier(

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -149,7 +149,7 @@ export function isERC1155TransferPayload(
  *
  * @export
  * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
- * @returns {*}
+ * @returns {Hex}
  * @throws {@link UnknownTransferPayloadSupplied}
  */
 export function prepareTransfer(
@@ -231,7 +231,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
    * @param {?WriteParams<typeof managedBudgetAbi, 'allocate'>} [params]
-   * @returns {Promise<boolean>} - True if the allocation was successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the allocation was successful
    */
   public async allocateRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
@@ -280,7 +280,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
    * @param {?WriteParams<typeof managedBudgetAbi, 'clawback'>} [params]
-   * @returns {Promise<boolean>} - True if the request was successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the request was successful
    */
   public async clawbackRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
@@ -325,7 +325,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
    * @param {?WriteParams<typeof managedBudgetAbi, 'disburse'>} [params]
-   * @returns {Promise<boolean>} - True if the disbursement was successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the disbursement was successful
    */
   public async disburseRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
@@ -368,7 +368,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {Array<FungibleTransferPayload | ERC1155TransferPayload>} transfers
    * @param {?WriteParams<typeof managedBudgetAbi, 'disburseBatch'>} [params]
-   * @returns {Promise<boolean>} - True if all disbursements were successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if all disbursements were successful
    */
   public async disburseBatchRaw(
     transfers: Array<FungibleTransferPayload | ERC1155TransferPayload>,
@@ -517,7 +517,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
  * @param {Address} param0.owner - The budget's owner
  * @param {{}} param0.authorized - List of accounts authorized to use the budget. This list should include a Boost core address to interact with the protocol.
  * @param {{}} param0.roles - List of roles to assign to the corresponding account by index.
- * @returns {*}
+ * @returns {Hex}
  */
 export const prepareManagedBudgetPayload = ({
   owner,

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -212,7 +212,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof managedBudgetAbi, 'allocate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the allocation was successful
    */
   public async allocate(
@@ -230,7 +230,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof managedBudgetAbi, 'allocate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the allocation was successful
    */
   public async allocateRaw(
@@ -260,7 +260,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof managedBudgetAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the request was successful
    */
   public async clawback(
@@ -279,7 +279,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof managedBudgetAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the request was successful
    */
   public async clawbackRaw(
@@ -307,7 +307,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof managedBudgetAbi, 'disburse'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the disbursement was successful
    */
   public async disburse(
@@ -324,7 +324,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof managedBudgetAbi, 'disburse'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the disbursement was successful
    */
   public async disburseRaw(
@@ -351,7 +351,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {Array<FungibleTransferPayload | ERC1155TransferPayload>} transfers
-   * @param {?WriteParams<typeof managedBudgetAbi, 'disburseBatch'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if all disbursements were successful
    */
   public async disburseBatch(
@@ -367,7 +367,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {Array<FungibleTransferPayload | ERC1155TransferPayload>} transfers
-   * @param {?WriteParams<typeof managedBudgetAbi, 'disburseBatch'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if all disbursements were successful
    */
   public async disburseBatchRaw(
@@ -392,7 +392,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * Get the owner of the budget
    *
    * @public
-   * @param {?ReadParams<typeof managedBudgetAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public owner(params?: ReadParams<typeof managedBudgetAbi, 'owner'>) {
@@ -411,7 +411,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @param {Address} [asset="0x0000000000000000000000000000000000000000"] - The address of the asset
    * @param {?(bigint | undefined)} [tokenId] - The ID of the token
-   * @param {?ReadParams<typeof managedBudgetAbi, 'total'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The total amount of assets
    */
   public total(
@@ -434,7 +434,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?(bigint | undefined)} [tokenId]
-   * @param {?ReadParams<typeof managedBudgetAbi, 'available'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The amount of assets available
    */
   public available(
@@ -457,7 +457,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @public
    * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?(bigint | undefined)} [tokenId]
-   * @param {?ReadParams<typeof managedBudgetAbi, 'distributed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The amount of assets distributed
    */
   public distributed(

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -160,7 +160,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    *
    * @public
    * @param {?ReadParams<typeof vestingBudgetAbi, 'start'>} [params]
-   * @returns {*}
+   * @returns {Promise<bigint>}
    */
   public start(params?: ReadParams<typeof vestingBudgetAbi, 'start'>) {
     return readVestingBudgetStart(this._config, {
@@ -176,7 +176,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    *
    * @public
    * @param {?ReadParams<typeof vestingBudgetAbi, 'duration'>} [params]
-   * @returns {*}
+   * @returns {Promise<bigint>}
    */
   public duration(params?: ReadParams<typeof vestingBudgetAbi, 'duration'>) {
     return readVestingBudgetDuration(this._config, {
@@ -192,7 +192,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    *
    * @public
    * @param {?ReadParams<typeof vestingBudgetAbi, 'cliff'>} [params]
-   * @returns {*}
+   * @returns {Promise<bigint>}
    */
   public cliff(params?: ReadParams<typeof vestingBudgetAbi, 'cliff'>) {
     return readVestingBudgetCliff(this._config, {
@@ -230,7 +230,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {(FungibleTransferPayload)} transfer
    * @param {?WriteParams<typeof vestingBudgetAbi, 'allocate'>} [params]
-   * @returns {Promise<boolean>} - True if the allocation was successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the allocation was successful
    */
   public async allocateRaw(
     transfer: FungibleTransferPayload,
@@ -279,7 +279,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {(FungibleTransferPayload)} transfer
    * @param {?WriteParams<typeof vestingBudgetAbi, 'clawback'>} [params]
-   * @returns {Promise<boolean>} - True if the request was successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the request was successful
    */
   public async clawbackRaw(
     transfer: FungibleTransferPayload,
@@ -324,7 +324,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {(FungibleTransferPayload)} transfer
    * @param {?WriteParams<typeof vestingBudgetAbi, 'disburse'>} [params]
-   * @returns {Promise<boolean>} - True if the disbursement was successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the disbursement was successful
    */
   public async disburseRaw(
     transfer: FungibleTransferPayload,
@@ -367,7 +367,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @async
    * @param {Array<FungibleTransferPayload>} transfers
    * @param {?WriteParams<typeof vestingBudgetAbi, 'disburseBatch'>} [params]
-   * @returns {Promise<boolean>} - True if all disbursements were successful
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if all disbursements were successful
    */
   public async disburseBatchRaw(
     transfers: FungibleTransferPayload[],

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -143,7 +143,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * Get the owner of the budget
    *
    * @public
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public owner(params?: ReadParams<typeof vestingBudgetAbi, 'owner'>) {
@@ -159,7 +159,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * The timestamp at which the vesting schedule begins
    *
    * @public
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'start'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public start(params?: ReadParams<typeof vestingBudgetAbi, 'start'>) {
@@ -175,7 +175,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * The duration of the vesting schedule (in seconds)
    *
    * @public
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'duration'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public duration(params?: ReadParams<typeof vestingBudgetAbi, 'duration'>) {
@@ -191,7 +191,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * The duration of the cliff period (in seconds)
    *
    * @public
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'cliff'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public cliff(params?: ReadParams<typeof vestingBudgetAbi, 'cliff'>) {
@@ -211,7 +211,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'allocate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the allocation was successful
    */
   public async allocate(
@@ -229,7 +229,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'allocate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the allocation was successful
    */
   public async allocateRaw(
@@ -259,7 +259,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the request was successful
    */
   public async clawback(
@@ -278,7 +278,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the request was successful
    */
   public async clawbackRaw(
@@ -306,7 +306,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'disburse'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the disbursement was successful
    */
   public async disburse(
@@ -323,7 +323,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'disburse'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if the disbursement was successful
    */
   public async disburseRaw(
@@ -350,7 +350,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {Array<FungibleTransferPayload>} transfers
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'disburseBatch'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if all disbursements were successful
    */
   public async disburseBatch(
@@ -366,7 +366,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @public
    * @async
    * @param {Array<FungibleTransferPayload>} transfers
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'disburseBatch'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - True if all disbursements were successful
    */
   public async disburseBatchRaw(
@@ -391,7 +391,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * Get the end time of the vesting schedule
    *
    * @public
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'end'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public end(params?: ReadParams<typeof vestingBudgetAbi, 'end'>) {
@@ -409,7 +409,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    *
    * @public
    * @param {Address} [asset="0x0000000000000000000000000000000000000000"] -  The address of the asset (or the zero address for native assets)
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'total'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public total(
@@ -430,7 +430,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    *
    * @public
    * @param {Address} [asset="0x0000000000000000000000000000000000000000"] -  The address of the asset (or the zero address for native assets)
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'available'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The amount of assets currently available for distribution
    */
   public available(
@@ -450,7 +450,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    *
    * @public
    * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
-   * @param {?ReadParams<typeof vestingBudgetAbi, 'distributed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The amount of assets distributed
    */
   public distributed(

--- a/packages/sdk/src/Deployable/Contract.ts
+++ b/packages/sdk/src/Deployable/Contract.ts
@@ -61,7 +61,7 @@ export class Contract<ContractAbi extends Abi> {
    *
    * @public
    * @readonly
-   * @type {*}
+   * @type {Address | undefined}
    */
   public get address() {
     return this._address;
@@ -174,7 +174,6 @@ export class Contract<ContractAbi extends Abi> {
    * A typed wrapper for `wagmi.watchContractEvent`
    *
    * @public
-   * @async
    * @template {ContractEvent} event
    * @param {(
    *       log: WatchContractEventOnLogsParameter<ContractAbi, event, true>[number],
@@ -182,9 +181,9 @@ export class Contract<ContractAbi extends Abi> {
    * @param {?WatchParams<ContractAbi, event> & {
    *       eventName?: event;
    *     }} [params]
-   * @returns {unknown, params?: any) => unknown}
+   * @returns {() => void}
    */
-  public async subscribe<event extends ContractEventName<ContractAbi>>(
+  public subscribe<event extends ContractEventName<ContractAbi>>(
     cb: (
       log: WatchContractEventOnLogsParameter<ContractAbi, event, true>[number],
     ) => unknown,
@@ -218,7 +217,7 @@ export class Contract<ContractAbi extends Abi> {
    * @template [Result=unknown]
    * @param {Promise<HashAndSimulatedResult<Result>>} hashPromise
    * @param {?Omit<WaitForTransactionReceiptParameters, 'hash'>} [waitParams]
-   * @returns {unknown}
+   * @returns {Promise<Result>}
    */
   protected async awaitResult<Result = unknown>(
     hashPromise: Promise<HashAndSimulatedResult<Result>>,

--- a/packages/sdk/src/Deployable/Deployable.ts
+++ b/packages/sdk/src/Deployable/Deployable.ts
@@ -149,7 +149,7 @@ export class Deployable<
    * @param {?Payload} [_payload]
    * @param {?DeployableOptions} [_options]
    * @param {?Omit<WaitForTransactionReceiptParameters, 'hash'>} [waitParams] - See [viem.WaitForTransactionReceipt](https://v1.viem.sh/docs/actions/public/waitForTransactionReceipt.html#waitfortransactionreceipt)
-   * @returns {unknown}
+   * @returns {Promise<this>}
    */
   protected async deploy(
     _payload?: Payload,

--- a/packages/sdk/src/Deployable/DeployableTarget.ts
+++ b/packages/sdk/src/Deployable/DeployableTarget.ts
@@ -131,7 +131,7 @@ export class DeployableTarget<
    * @param {?Payload} [payload]
    * @param {?DeployableOptions} [options]
    * @param {?Omit<WaitForTransactionReceiptParameters, 'hash'>} [waitParams]
-   * @returns {unknown}
+   * @returns {Promise<this>}
    */
   protected override async deploy(
     payload?: Payload,
@@ -175,7 +175,7 @@ export class DeployableTarget<
    * @async
    * @param {Hex} interfaceId - The interface identifier
    * @param {?ReadParams<typeof contractActionAbi, 'supportsInterface'>} [params]
-   * @returns {unknown} - True if the contract supports the interface
+   * @returns {Promise<boolean>} - True if the contract supports the interface
    */
   public async supportsInterface(
     interfaceId: Hex,
@@ -197,7 +197,7 @@ export class DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof contractActionAbi, 'getComponentInterface'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Hex>}
    */
   public async getComponentInterface(
     params?: ReadParams<typeof aCloneableAbi, 'getComponentInterface'>,

--- a/packages/sdk/src/Deployable/DeployableTarget.ts
+++ b/packages/sdk/src/Deployable/DeployableTarget.ts
@@ -174,7 +174,7 @@ export class DeployableTarget<
    * @public
    * @async
    * @param {Hex} interfaceId - The interface identifier
-   * @param {?ReadParams<typeof contractActionAbi, 'supportsInterface'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the contract supports the interface
    */
   public async supportsInterface(
@@ -196,7 +196,7 @@ export class DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof contractActionAbi, 'getComponentInterface'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
   public async getComponentInterface(

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -120,7 +120,7 @@ export class DeployableTargetWithRBAC<
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
    * @param {?WriteParams<typeof rbacAbi, 'grantRoles'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<void>}
    */
   public async grantRoles(
     addresses: Address[],
@@ -142,7 +142,7 @@ export class DeployableTargetWithRBAC<
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
    * @param {?WriteParams<typeof rbacAbi, 'grantRoles'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async grantRolesRaw(
     addresses: Address[],
@@ -176,7 +176,7 @@ export class DeployableTargetWithRBAC<
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
    * @param {?WriteParams<typeof rbacAbi, 'revokeRoles'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<void>}
    */
   public async revokeRoles(
     addresses: Address[],
@@ -199,7 +199,7 @@ export class DeployableTargetWithRBAC<
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
    * @param {?WriteParams<typeof rbacAbi, 'revokeRoles'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async revokeRolesRaw(
     addresses: Address[],
@@ -284,7 +284,7 @@ export class DeployableTargetWithRBAC<
    * @param {Address} account
    * @param {RbacRoles} roles
    * @param {?ReadParams<typeof rbacAbi, 'hasAllRoles'>} [params]
-   * @returns {*}
+   * @returns {Promise<boolean>}
    */
   public hasAllRoles(
     account: Address,

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -68,7 +68,7 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses - The accounts to authorize or deauthorize
    * @param {boolean[]} allowed - The authorization status for the given accounts
-   * @param {?WriteParams<typeof rbacAbi, 'setAuthorized'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async setAuthorized(
@@ -89,7 +89,7 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses - The accounts to authorize or deauthorize
    * @param {boolean[]} allowed - The authorization status for the given accounts
-   * @param {?WriteParams<typeof rbacAbi, 'setAuthorized'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async setAuthorizedRaw(
@@ -119,7 +119,7 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
-   * @param {?WriteParams<typeof rbacAbi, 'grantRoles'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async grantRoles(
@@ -141,7 +141,7 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
-   * @param {?WriteParams<typeof rbacAbi, 'grantRoles'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async grantRolesRaw(
@@ -175,7 +175,7 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
-   * @param {?WriteParams<typeof rbacAbi, 'revokeRoles'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async revokeRoles(
@@ -198,7 +198,7 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address[]} addresses
    * @param {RbacRoles[]} roles
-   * @param {?WriteParams<typeof rbacAbi, 'revokeRoles'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async revokeRolesRaw(
@@ -228,7 +228,7 @@ export class DeployableTargetWithRBAC<
    * (await rbac.rolesOf(0xfoo)).includes(RbacRoles.ADMIN)
    * @public
    * @param {Address} account
-   * @param {?ReadParams<typeof rbacAbi, 'rolesOf'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Array<RbacRoles>>}
    */
   public async rolesOf(
@@ -256,7 +256,7 @@ export class DeployableTargetWithRBAC<
    * @public
    * @param {Address} account
    * @param {RbacRoles} roles
-   * @param {?ReadParams<typeof rbacAbi, 'hasAnyRole'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public hasAnyRole(
@@ -283,7 +283,7 @@ export class DeployableTargetWithRBAC<
    * @public
    * @param {Address} account
    * @param {RbacRoles} roles
-   * @param {?ReadParams<typeof rbacAbi, 'hasAllRoles'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public hasAllRoles(
@@ -305,7 +305,7 @@ export class DeployableTargetWithRBAC<
    *
    * @public
    * @param {Address} account
-   * @param {?ReadParams<typeof rbacAbi, 'isAuthorized'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the account is authorized
    */
   public isAuthorized(

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -113,7 +113,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof allowListIncentiveAbi, 'owner'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async owner(
     params?: ReadParams<typeof allowListIncentiveAbi, 'owner'>,
@@ -213,7 +213,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof allowListIncentiveAbi, 'limit'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>}
    */
   public async limit(
     params?: ReadParams<typeof allowListIncentiveAbi, 'limit'>,
@@ -248,7 +248,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @async
    * @param {Pick<ClaimPayload, 'target'>} payload
    * @param {?WriteParams<typeof allowListIncentiveAbi, 'claim'>} [params]
-   * @returns {Promise<true>} - return true if successful, otherwise revert
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - return true if successful, otherwise revert
    */
   protected async claimRaw(
     payload: Pick<ClaimPayload, 'target'>,

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -112,7 +112,7 @@ export class AllowListIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async owner(
@@ -131,7 +131,7 @@ export class AllowListIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'claims'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async claims(
@@ -150,7 +150,7 @@ export class AllowListIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'reward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async reward(
@@ -170,7 +170,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'claimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async claimed(
@@ -190,7 +190,7 @@ export class AllowListIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'allowList'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<SimpleAllowList>}
    */
   public async allowList(
@@ -212,7 +212,7 @@ export class AllowListIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'limit'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async limit(
@@ -231,7 +231,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Pick<ClaimPayload, 'target'>} payload
-   * @param {?WriteParams<typeof allowListIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<true>} - return true if successful, otherwise revert
    */
   protected async claim(
@@ -247,7 +247,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Pick<ClaimPayload, 'target'>} payload
-   * @param {?WriteParams<typeof allowListIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - return true if successful, otherwise revert
    */
   protected async claimRaw(
@@ -274,7 +274,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Pick<ClaimPayload, 'target'>} payload
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'isClaimable'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the incentive is claimable based on the data payload
    */
   public async isClaimable(

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -165,7 +165,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof cgdaIncentiveAbi, 'owner'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async owner(params?: ReadParams<typeof cgdaIncentiveAbi, 'owner'>) {
     return await readCgdaIncentiveOwner(this._config, {
@@ -237,7 +237,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof cgdaIncentiveAbi, 'asset'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async asset(params?: ReadParams<typeof cgdaIncentiveAbi, 'asset'>) {
     return await readCgdaIncentiveAsset(this._config, {

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -164,7 +164,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async owner(params?: ReadParams<typeof cgdaIncentiveAbi, 'owner'>) {
@@ -181,7 +181,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'claims'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async claims(params?: ReadParams<typeof cgdaIncentiveAbi, 'claims'>) {
@@ -198,7 +198,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof allowListIncentiveAbi, 'reward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async reward(params?: ReadParams<typeof cgdaIncentiveAbi, 'reward'>) {
@@ -216,7 +216,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'claimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async claimed(
@@ -236,7 +236,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'asset'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async asset(params?: ReadParams<typeof cgdaIncentiveAbi, 'asset'>) {
@@ -252,7 +252,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'cgdaParams'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<CGDAParameters>}
    */
   public async cgdaParams(
@@ -277,7 +277,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'totalBudget'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async totalBudget(
@@ -296,7 +296,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
   protected async claim(
@@ -312,7 +312,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
   protected async claimRaw(
@@ -336,7 +336,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
   public async clawback(
@@ -352,7 +352,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
   public async clawbackRaw(
@@ -379,7 +379,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'isClaimable'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the incentive is claimable based on the data payload
    */
   public async isClaimable(
@@ -401,7 +401,7 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof cgdaIncentiveAbi, 'currentReward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
   public async currentReward(

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -145,7 +145,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'claims'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>}
    */
   public async claims(
     params?: ReadParams<typeof erc1155IncentiveAbi, 'claims'>,
@@ -164,7 +164,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'reward'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>}
    */
   public async reward(
     params?: ReadParams<typeof erc1155IncentiveAbi, 'reward'>,
@@ -184,7 +184,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {Address} address
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'claimed'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   public async claimed(
     address: Address,
@@ -204,7 +204,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'asset'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async asset(params?: ReadParams<typeof erc1155IncentiveAbi, 'asset'>) {
     return await readErc1155IncentiveAsset(this._config, {
@@ -254,7 +254,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'tokenId'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>}
    */
   public async tokenId(
     params?: ReadParams<typeof erc1155IncentiveAbi, 'tokenId'>,
@@ -272,7 +272,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'extraData'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Hex>}
    */
   public async extraData(
     params?: ReadParams<typeof erc1155IncentiveAbi, 'extraData'>,
@@ -291,7 +291,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc1155IncentiveAbi, 'claim'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   protected async claim(
     payload: ClaimPayload,
@@ -307,7 +307,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc1155IncentiveAbi, 'claim'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>}
    */
   protected async claimRaw(
     payload: ClaimPayload,
@@ -334,7 +334,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc1155IncentiveAbi, 'clawback'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   public async clawback(
     payload: ClaimPayload,
@@ -350,7 +350,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc1155IncentiveAbi, 'clawback'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>}
    */
   public async clawbackRaw(
     payload: ClaimPayload,
@@ -377,7 +377,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'isClaimable'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   public async isClaimable(
     payload: ClaimPayload,
@@ -398,7 +398,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @async
    * @param {ERC1155IncentivePayload} data
    * @param {?ReadParams<typeof erc1155IncentiveAbi, 'preflight'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Hex>}
    */
   public async preflight(
     data: ERC1155IncentivePayload,

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -144,7 +144,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'claims'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async claims(
@@ -163,7 +163,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'reward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async reward(
@@ -183,7 +183,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'claimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async claimed(
@@ -203,7 +203,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'asset'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async asset(params?: ReadParams<typeof erc1155IncentiveAbi, 'asset'>) {
@@ -219,7 +219,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'strategy'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<StrategyType>}
    */
   public strategy(
@@ -237,7 +237,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'limit'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {unknown}
    */
   public async limit(params?: ReadParams<typeof erc1155IncentiveAbi, 'limit'>) {
@@ -253,7 +253,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'tokenId'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async tokenId(
@@ -271,7 +271,7 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'extraData'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
   public async extraData(
@@ -290,7 +290,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>}
    */
   protected async claim(
@@ -306,7 +306,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>}
    */
   protected async claimRaw(
@@ -333,7 +333,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>}
    */
   public async clawback(
@@ -349,7 +349,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>}
    */
   public async clawbackRaw(
@@ -376,7 +376,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'isClaimable'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async isClaimable(
@@ -397,7 +397,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ERC1155IncentivePayload} data
-   * @param {?ReadParams<typeof erc1155IncentiveAbi, 'preflight'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
   public async preflight(

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -130,7 +130,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async owner(params?: ReadParams<typeof erc20IncentiveAbi, 'owner'>) {
@@ -147,7 +147,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'currentReward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
   public async currentReward(
@@ -166,7 +166,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'claims'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async claims(params?: ReadParams<typeof erc20IncentiveAbi, 'claims'>) {
@@ -184,7 +184,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'claimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async claimed(
@@ -204,7 +204,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'asset'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async asset(params?: ReadParams<typeof erc20IncentiveAbi, 'asset'>) {
@@ -220,7 +220,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'strategy'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<StrategyType>}
    */
   public strategy(
@@ -238,7 +238,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'reward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async reward(params?: ReadParams<typeof erc20IncentiveAbi, 'reward'>) {
@@ -254,7 +254,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'limit'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async limit(params?: ReadParams<typeof erc20IncentiveAbi, 'limit'>) {
@@ -271,7 +271,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {bigint} i - Index of address
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'entries'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async entries(
@@ -292,7 +292,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
   protected async claim(
@@ -308,7 +308,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
    */
   protected async claimRaw(
@@ -335,7 +335,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
   public async clawback(
@@ -351,7 +351,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
    */
   public async clawbackRaw(
@@ -378,7 +378,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'isClaimable'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
    */
   public async isClaimable(
@@ -398,7 +398,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'drawRaffle'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async drawRaffle(
@@ -412,7 +412,7 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'drawRaffle'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async drawRaffleRaw(

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -131,7 +131,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc20IncentiveAbi, 'owner'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async owner(params?: ReadParams<typeof erc20IncentiveAbi, 'owner'>) {
     return await readErc20IncentiveOwner(this._config, {
@@ -255,7 +255,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc20IncentiveAbi, 'limit'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>}
    */
   public async limit(params?: ReadParams<typeof erc20IncentiveAbi, 'limit'>) {
     return await readErc20IncentiveLimit(this._config, {
@@ -309,7 +309,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc20IncentiveAbi, 'claim'>} [params]
-   * @returns {Promise<boolean>} - Returns true if successfully claimed
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
    */
   protected async claimRaw(
     payload: ClaimPayload,
@@ -352,7 +352,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc20IncentiveAbi, 'clawback'>} [params]
-   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
    */
   public async clawbackRaw(
     payload: ClaimPayload,
@@ -379,7 +379,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?ReadParams<typeof erc20IncentiveAbi, 'isClaimable'>} [params]
-   * @returns {unknown} = True if the incentive is claimable based on the data payload
+   * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
    */
   public async isClaimable(
     payload: ClaimPayload,
@@ -413,7 +413,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {?WriteParams<typeof erc20IncentiveAbi, 'drawRaffle'>} [params]
-   * @returns {Promise<void>}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async drawRaffleRaw(
     params?: WriteParams<typeof erc20IncentiveAbi, 'drawRaffle'>,
@@ -464,7 +464,7 @@ export class ERC20Incentive extends DeployableTarget<
  * @param {StrategyType} param0.strategy - The type of disbursement strategy for the incentive. `StrategyType.MINT` is not supported for `ERC20Incentives`
  * @param {bigint} param0.reward - The amount of the asset to distribute.
  * @param {bigint} param0.limit - How many times can this incentive be claimed.
- * @returns {*}
+ * @returns {Hex}
  */
 export function prepareERC20IncentivePayload({
   asset,

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -116,7 +116,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'owner'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async owner(
@@ -135,7 +135,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'totalClaimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async totalClaimed(
@@ -154,7 +154,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'currentReward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
   public async currentReward(
@@ -173,7 +173,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'claims'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async claims(
@@ -193,7 +193,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'claimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async claimed(
@@ -213,7 +213,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'asset'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async asset(
@@ -231,7 +231,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'reward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async reward(
@@ -249,7 +249,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'limit'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async limit(
@@ -268,7 +268,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20VariableIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
   protected async claim(
@@ -284,7 +284,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20VariableIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
    */
   protected async claimRaw(
@@ -311,7 +311,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20VariableIncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
   public async clawback(
@@ -327,7 +327,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20VariableIncentiveAbi, 'clawback'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
    */
   public async clawbackRaw(
@@ -357,7 +357,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'isClaimable'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
    */
   public async isClaimable(

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -117,7 +117,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'owner'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async owner(
     params?: ReadParams<typeof erc20VariableIncentiveAbi, 'owner'>,
@@ -250,7 +250,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'limit'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>}
    */
   public async limit(
     params?: ReadParams<typeof erc20VariableIncentiveAbi, 'limit'>,
@@ -285,7 +285,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc20VariableIncentiveAbi, 'claim'>} [params]
-   * @returns {Promise<boolean>} - Returns true if successfully claimed
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
    */
   protected async claimRaw(
     payload: ClaimPayload,
@@ -328,7 +328,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof erc20VariableIncentiveAbi, 'clawback'>} [params]
-   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
    */
   public async clawbackRaw(
     payload: ClaimPayload,
@@ -358,7 +358,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?ReadParams<typeof erc20VariableIncentiveAbi, 'isClaimable'>} [params]
-   * @returns {unknown} = True if the incentive is claimable based on the data payload
+   * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
    */
   public async isClaimable(
     payload: ClaimPayload,
@@ -404,7 +404,7 @@ export class ERC20VariableIncentive extends DeployableTarget<
  * @param {Address} param0.asset - The address of the incentivized asset.
  * @param {bigint} param0.reward - The amount of the asset to distribute.
  * @param {bigint} param0.limit - How many times can this incentive be claimed.
- * @returns {*}
+ * @returns {Hex}
  */
 export function prepareERC20VariableIncentivePayload({
   asset,

--- a/packages/sdk/src/Incentives/Incentive.ts
+++ b/packages/sdk/src/Incentives/Incentive.ts
@@ -62,7 +62,7 @@ export const IncentiveByComponentInterface = {
  * @async
  * @param {DeployableOptions} options
  * @param {Address} address
- * @returns {unknown}
+ * @returns {Incentive}
  * @throws {@link InvalidComponentInterfaceError}
  */
 export async function incentiveFromAddress(

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -125,7 +125,7 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'claims'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async claims(
@@ -144,7 +144,7 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof erc20IncentiveAbi, 'currentReward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
   public async currentReward(
@@ -163,7 +163,7 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof pointsIncentiveAbi, 'reward'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} The reward amount issued for each claim
    */
   public async reward(
@@ -183,7 +183,7 @@ export class PointsIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof pointsIncentiveAbi, 'claimed'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async claimed(
@@ -203,7 +203,7 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof pointsIncentiveAbi, 'venue'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
   public async venue(params?: ReadParams<typeof pointsIncentiveAbi, 'venue'>) {
@@ -219,7 +219,7 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof pointsIncentiveAbi, 'limit'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
   public async limit(params?: ReadParams<typeof pointsIncentiveAbi, 'limit'>) {
@@ -235,7 +235,7 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ReadParams<typeof pointsIncentiveAbi, 'selector'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
   public async selector(
@@ -254,7 +254,7 @@ export class PointsIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof pointsIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the incentive was successfully claimed
    */
   protected async claim(
@@ -270,7 +270,7 @@ export class PointsIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof pointsIncentiveAbi, 'claim'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the incentive was successfully claimed
    */
   protected async claimRaw(
@@ -299,7 +299,7 @@ export class PointsIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?ReadParams<typeof pointsIncentiveAbi, 'isClaimable'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} -  True if the incentive is claimable based on the data payload
    */
   public async isClaimable(

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -164,7 +164,7 @@ export class PointsIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof pointsIncentiveAbi, 'reward'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<bigint>} The reward amount issued for each claim
    */
   public async reward(
     params?: ReadParams<typeof pointsIncentiveAbi, 'reward'>,
@@ -184,7 +184,7 @@ export class PointsIncentive extends DeployableTarget<
    * @async
    * @param {Address} address
    * @param {?ReadParams<typeof pointsIncentiveAbi, 'claimed'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   public async claimed(
     address: Address,
@@ -204,7 +204,7 @@ export class PointsIncentive extends DeployableTarget<
    * @public
    * @async
    * @param {?ReadParams<typeof pointsIncentiveAbi, 'venue'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Address>}
    */
   public async venue(params?: ReadParams<typeof pointsIncentiveAbi, 'venue'>) {
     return await readPointsIncentiveVenue(this._config, {
@@ -271,7 +271,7 @@ export class PointsIncentive extends DeployableTarget<
    * @async
    * @param {ClaimPayload} payload
    * @param {?WriteParams<typeof pointsIncentiveAbi, 'claim'>} [params]
-   * @returns {Promise<boolean>} -  True if the incentive was successfully claimed
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the incentive was successfully claimed
    */
   protected async claimRaw(
     payload: ClaimPayload,

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -327,7 +327,7 @@ export class SignerValidator extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?ReadParams<typeof signerValidatorAbi, 'signers'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async signers(
@@ -348,7 +348,7 @@ export class SignerValidator extends DeployableTarget<
    * @public
    * @async
    * @param {SignerValidatorSignaturePayload} payload
-   * @param {?ReadParams<typeof signerValidatorAbi, 'hashSignerData'>} [params]
+   * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
   public async hashSignerData(
@@ -374,7 +374,7 @@ export class SignerValidator extends DeployableTarget<
    * @public
    * @async
    * @param {SignerValidatorValidatePayload} payload
-   * @param {?WriteParams<typeof signerValidatorAbi, 'validate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the action has been validated based on the data payload
    */
   protected async validate(
@@ -390,7 +390,7 @@ export class SignerValidator extends DeployableTarget<
    * @public
    * @async
    * @param {SignerValidatorValidatePayload} payload
-   * @param {?WriteParams<typeof signerValidatorAbi, 'validate'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - True if the action has been validated based on the data payload
    */
   protected async validateRaw(
@@ -423,7 +423,7 @@ export class SignerValidator extends DeployableTarget<
    * @async
    * @param {Address[]} addresses - The list of signers to update
    * @param {boolean[]} allowed - The authorized status of each signer
-   * @param {?WriteParams<typeof signerValidatorAbi, 'setAuthorized'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async setAuthorized(
@@ -443,7 +443,7 @@ export class SignerValidator extends DeployableTarget<
    * @async
    * @param {Address[]} addresses - The list of signers to update
    * @param {boolean[]} allowed - The authorized status of each signer
-   * @param {?WriteParams<typeof signerValidatorAbi, 'setAuthorized'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setAuthorizedRaw(
@@ -471,7 +471,7 @@ export class SignerValidator extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setValidatorCallerRaw(
@@ -501,7 +501,7 @@ export class SignerValidator extends DeployableTarget<
    * @public
    * @async
    * @param {Address} address
-   * @param {?WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
   public async setValidatorCaller(

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -328,7 +328,7 @@ export class SignerValidator extends DeployableTarget<
    * @async
    * @param {Address} address
    * @param {?ReadParams<typeof signerValidatorAbi, 'signers'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<boolean>}
    */
   public async signers(
     address: Address,
@@ -349,7 +349,7 @@ export class SignerValidator extends DeployableTarget<
    * @async
    * @param {SignerValidatorSignaturePayload} payload
    * @param {?ReadParams<typeof signerValidatorAbi, 'hashSignerData'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<Hex>}
    */
   public async hashSignerData(
     payload: SignerValidatorSignaturePayload,
@@ -424,7 +424,7 @@ export class SignerValidator extends DeployableTarget<
    * @param {Address[]} addresses - The list of signers to update
    * @param {boolean[]} allowed - The authorized status of each signer
    * @param {?WriteParams<typeof signerValidatorAbi, 'setAuthorized'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<void>}
    */
   public async setAuthorized(
     addresses: Address[],
@@ -444,7 +444,7 @@ export class SignerValidator extends DeployableTarget<
    * @param {Address[]} addresses - The list of signers to update
    * @param {boolean[]} allowed - The authorized status of each signer
    * @param {?WriteParams<typeof signerValidatorAbi, 'setAuthorized'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setAuthorizedRaw(
     addresses: Address[],
@@ -472,7 +472,7 @@ export class SignerValidator extends DeployableTarget<
    * @async
    * @param {Address} address
    * @param {?WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
   public async setValidatorCallerRaw(
     address: Address,
@@ -502,7 +502,7 @@ export class SignerValidator extends DeployableTarget<
    * @async
    * @param {Address} address
    * @param {?WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>} [params]
-   * @returns {unknown}
+   * @returns {Promise<void>}
    */
   public async setValidatorCaller(
     address: Address,

--- a/packages/sdk/src/Validators/Validator.ts
+++ b/packages/sdk/src/Validators/Validator.ts
@@ -32,7 +32,7 @@ export const ValidatorByComponentInterface = {
  * @async
  * @param {DeployableOptions} options
  * @param {Address} address
- * @returns {unknown}
+ * @returns {Promise<Validator>}
  * @throws {@link InvalidComponentInterfaceError}
  */
 export async function validatorFromAddress(

--- a/packages/sdk/src/claiming.ts
+++ b/packages/sdk/src/claiming.ts
@@ -40,7 +40,7 @@ export interface ClaimPayload {
  * @param {ClaimPayload} param0
  * @param {Address} param0.target - The address of the recipient
  * @param {Hex} [param0.data=zeroHash] - The implementation-specific data for the claim, if needed
- * @returns {*}
+ * @returns {Hex}
  */
 export const prepareClaimPayload = ({
   target,

--- a/packages/sdk/src/transfers.ts
+++ b/packages/sdk/src/transfers.ts
@@ -211,7 +211,7 @@ export interface FungiblePayload {
  * @export
  * @param {FungiblePayload} param0
  * @param {bigint} param0.amount - The amount being transferred
- * @returns {*}
+ * @returns {Hex}
  */
 export function prepareFungiblePayload({ amount }: FungiblePayload) {
   return encodeAbiParameters(

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -154,7 +154,7 @@ export function bytes4(input: string) {
  * @param {WagmiConfig} config - [Wagmi Configuration](https://wagmi.sh/core/api/createConfig)
  * @param {Promise<Hash>} hash - A transaction hash promise
  * @param {?Omit<WaitForTransactionReceiptParameters, 'hash'>} [waitParams] - @see {@link WaitForTransactionReceiptParameters}
- * @returns {unknown}
+ * @returns {Promise<Address>}
  * @throws {@link NoContractAddressUponReceiptError} if no `contractAddress` exists after the transaction has been received
  */
 export async function getDeployedContractAddress(


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/rabbitholegg/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description

- a lot of typedoc return types were either missing or incorrect, making the generated docs confusing
- in typedocs, remove the `ReadParams/WriteParams<typeof abi, 'function'>` generics to get rid of the entire abi being inlined in the typedoc. The interfaces are still correct in type definitions, but this should greatly reduce noise in the docs site

![image](https://github.com/user-attachments/assets/f6cc8406-1baf-4243-8ac7-232600961ebb)


💔 Thank you!
