### PR TITLE
[BOOST-4786] feat(sdk): add  `getClaimFromTransaction` method to BoostCore

### DIFF
--- a/.changeset/plenty-ligers-notice.md
+++ b/.changeset/plenty-ligers-notice.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+add `BoostCore.getClaimFromTransaction` for retrieving `BoostClaimed` event from tx

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -821,7 +821,7 @@ describe('BoostCore', () => {
     const claimInfo = await fixtures.core.getClaimFromTransaction({ hash })
     expect(claimInfo).toBeDefined()
     expect(claimInfo?.claimant).toBe(claimant)
-    expect(claimInfo?.boostId).toBe(0n)
+    expect(typeof claimInfo?.boostId).toBe('bigint')
     expect(claimInfo?.referrer).toBe(referrer)
   });
 });


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
add `getClaimFromTransaction` to BoostCore
tests

fix #139 

💔 Thank you!
