### PR TITLE
[BOOST-4780] feat: Implement `clawBackFromIncentive`

### DIFF
--- a/examples/zora-mint/src/zora-mint.test.ts
+++ b/examples/zora-mint/src/zora-mint.test.ts
@@ -132,6 +132,7 @@ describe("Boost with NFT Minting Incentive", () => {
           reward: parseEther("1"),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });

--- a/packages/evm/contracts/incentives/ERC20Incentive.sol
+++ b/packages/evm/contracts/incentives/ERC20Incentive.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
-import {Ownable as AOwnable} from "@solady/auth/Ownable.sol";
 import {LibPRNG} from "@solady/utils/LibPRNG.sol";
 import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 
@@ -10,10 +9,11 @@ import {BoostError} from "contracts/shared/BoostError.sol";
 import {AERC20Incentive} from "contracts/incentives/AERC20Incentive.sol";
 import {AIncentive} from "contracts/incentives/AIncentive.sol";
 import {ABudget} from "contracts/budgets/ABudget.sol";
+import {RBAC} from "contracts/shared/RBAC.sol";
 
 /// @title ERC20 AIncentive
 /// @notice A simple ERC20 incentive implementation that allows claiming of tokens
-contract ERC20Incentive is AOwnable, AERC20Incentive {
+contract ERC20Incentive is RBAC, AERC20Incentive {
     using LibPRNG for LibPRNG.PRNG;
     using SafeTransferLib for address;
 
@@ -23,6 +23,7 @@ contract ERC20Incentive is AOwnable, AERC20Incentive {
         Strategy strategy;
         uint256 reward;
         uint256 limit;
+        address manager;
     }
 
     /// @notice Construct a new ERC20Incentive
@@ -50,6 +51,7 @@ contract ERC20Incentive is AOwnable, AERC20Incentive {
         reward = init_.reward;
         limit = init_.limit;
         _initializeOwner(msg.sender);
+        _setRoles(init_.manager, MANAGER_ROLE);
     }
 
     /// @inheritdoc AIncentive
@@ -95,7 +97,7 @@ contract ERC20Incentive is AOwnable, AERC20Incentive {
     }
 
     /// @inheritdoc AIncentive
-    function clawback(bytes calldata data_) external override onlyOwner returns (bool) {
+    function clawback(bytes calldata data_) external override onlyRoles(MANAGER_ROLE) returns (bool) {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 

--- a/packages/evm/contracts/shared/RBAC.sol
+++ b/packages/evm/contracts/shared/RBAC.sol
@@ -9,7 +9,7 @@ import {BoostError} from "contracts/shared/BoostError.sol";
 /// @notice A minimal )
 /// @dev This type of budget supports ETH, ERC20, and ERC1155 assets only
 contract RBAC is OwnableRoles {
-    /// @notice The role for depositing funds.
+    /// @notice The role for managing allocations to Incentives.
     uint256 public constant MANAGER_ROLE = _ROLE_0;
     /// @notice The role for depositing, withdrawal, and manager management
     uint256 public constant ADMIN_ROLE = _ROLE_1;

--- a/packages/evm/script/solidity/ComponentInterface.s.sol
+++ b/packages/evm/script/solidity/ComponentInterface.s.sol
@@ -51,19 +51,8 @@ contract LogComponentInterface is ScriptUtils {
         _saveJson();
     }
 
-    function _buildJsonDeployPath()
-        internal
-        view
-        override
-        returns (string memory)
-    {
-        return
-            string(
-                abi.encodePacked(
-                    vm.projectRoot(),
-                    "/deploys/componentInterfaces.json"
-                )
-            );
+    function _buildJsonDeployPath() internal view override returns (string memory) {
+        return string(abi.encodePacked(vm.projectRoot(), "/deploys/componentInterfaces.json"));
     }
 
     function _saveJson() internal {
@@ -71,129 +60,72 @@ contract LogComponentInterface is ScriptUtils {
     }
 
     function _getInterfaceAManagedBudget() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AManagedBudget).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "AManagedBudget",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(AManagedBudget).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("AManagedBudget", interfaceId);
     }
 
     function _getInterfaceAEventAction() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AEventAction).interfaceId)
-        ).toHexString(4);
+        string memory interfaceId = uint256(uint32(type(AEventAction).interfaceId)).toHexString(4);
         componentJson = componentJsonKey.serialize("AEventAction", interfaceId);
     }
 
     function _getInterfaceAERC20Incentive() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AERC20Incentive).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "AERC20Incentive",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(AERC20Incentive).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("AERC20Incentive", interfaceId);
     }
 
     function _getInterfaceACloneable() internal {
-        string memory interfaceId = uint256(
-            uint32(type(ACloneable).interfaceId)
-        ).toHexString(4);
+        string memory interfaceId = uint256(uint32(type(ACloneable).interfaceId)).toHexString(4);
         componentJson = componentJsonKey.serialize("ACloneable", interfaceId);
     }
 
     function _getInterfaceABudget() internal {
-        string memory interfaceId = uint256(uint32(type(ABudget).interfaceId))
-            .toHexString(4);
+        string memory interfaceId = uint256(uint32(type(ABudget).interfaceId)).toHexString(4);
         componentJson = componentJsonKey.serialize("ABudget", interfaceId);
     }
 
     function _getInterfaceAVestingBudget() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AVestingBudget).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "AVestingBudget",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(AVestingBudget).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("AVestingBudget", interfaceId);
     }
 
     function _getInterfaceASignerValidator() internal {
-        string memory interfaceId = uint256(
-            uint32(type(ASignerValidator).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "ASignerValidator",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(ASignerValidator).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("ASignerValidator", interfaceId);
     }
 
     function _getInterfaceAAllowListIncentive() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AAllowListIncentive).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "AAllowListIncentive",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(AAllowListIncentive).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("AAllowListIncentive", interfaceId);
     }
 
     function _getInterfaceACGDAIncentive() internal {
-        string memory interfaceId = uint256(
-            uint32(type(ACGDAIncentive).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "ACGDAIncentive",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(ACGDAIncentive).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("ACGDAIncentive", interfaceId);
     }
 
     function _getInterfaceAIncentive() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AIncentive).interfaceId)
-        ).toHexString(4);
+        string memory interfaceId = uint256(uint32(type(AIncentive).interfaceId)).toHexString(4);
         componentJson = componentJsonKey.serialize("AIncentive", interfaceId);
     }
 
     function _getInterfaceAERC20VariableIncentive() internal {
-        string memory interfaceId = uint256(
-            uint32(type(AERC20VariableIncentive).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "AERC20VariableIncentive",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(AERC20VariableIncentive).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("AERC20VariableIncentive", interfaceId);
     }
 
     function _getInterfaceAPointsIncentive() internal {
-        string memory interfaceId = uint256(
-            uint32(type(APointsIncentive).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "APointsIncentive",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(APointsIncentive).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("APointsIncentive", interfaceId);
     }
 
     function _getInterfaceASimpleAllowList() internal {
-        string memory interfaceId = uint256(
-            uint32(type(ASimpleAllowList).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "ASimpleAllowList",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(ASimpleAllowList).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("ASimpleAllowList", interfaceId);
     }
 
     function _getInterfaceASimpleDenyList() internal {
-        string memory interfaceId = uint256(
-            uint32(type(ASimpleDenyList).interfaceId)
-        ).toHexString(4);
-        componentJson = componentJsonKey.serialize(
-            "ASimpleDenyList",
-            interfaceId
-        );
+        string memory interfaceId = uint256(uint32(type(ASimpleDenyList).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("ASimpleDenyList", interfaceId);
     }
 }

--- a/packages/evm/script/solidity/Deploy_Modules.s.sol
+++ b/packages/evm/script/solidity/Deploy_Modules.s.sol
@@ -68,7 +68,9 @@ contract ModuleBaseDeployer is ScriptUtils {
             string(abi.encodePacked(vm.projectRoot(), "/deploys/", vm.toString(block.chainid), ".json"));
         deployJson = vm.readFile(path);
         deployJson = deployJsonKey.serialize(deployJson);
-        if (!vm.keyExistsJson(deployJson, ".BoostRegistry")) revert("No registry deployed: run `pnpm deploy:core:local");
+        if (!vm.keyExistsJson(deployJson, ".BoostRegistry")) {
+            revert("No registry deployed: run `pnpm deploy:core:local");
+        }
         return BoostRegistry(deployJson.readAddress(".BoostRegistry"));
     }
 
@@ -105,7 +107,9 @@ contract ModuleBaseDeployer is ScriptUtils {
         console.log("ERC20VariableIncentive: ", erc20VariableIncentive);
         deployJson = deployJsonKey.serialize("ERC20VariableIncentive", erc20VariableIncentive);
         bool newDeploy = _deploy2(initCode, "");
-        _registerIfNew(newDeploy, "ERC20VariableIncentive", erc20VariableIncentive, registry, ABoostRegistry.RegistryType.INCENTIVE);
+        _registerIfNew(
+            newDeploy, "ERC20VariableIncentive", erc20VariableIncentive, registry, ABoostRegistry.RegistryType.INCENTIVE
+        );
     }
 
     function _deployERC20VariableCriteriaIncentive(BoostRegistry registry) internal returns (address erc20VariableCriteriaIncentive) {
@@ -141,7 +145,9 @@ contract ModuleBaseDeployer is ScriptUtils {
         console.log("AllowListIncentive: ", allowListIncentive);
         deployJson = deployJsonKey.serialize("AllowListIncentive", allowListIncentive);
         bool newDeploy = _deploy2(initCode, "");
-        _registerIfNew(newDeploy, "AllowListIncentive", allowListIncentive, registry, ABoostRegistry.RegistryType.INCENTIVE);
+        _registerIfNew(
+            newDeploy, "AllowListIncentive", allowListIncentive, registry, ABoostRegistry.RegistryType.INCENTIVE
+        );
     }
 
     function _deploySignerValidator(BoostRegistry registry) internal returns (address signerValidator) {
@@ -186,4 +192,5 @@ contract ModuleBaseDeployer is ScriptUtils {
         deployJson = deployJsonKey.serialize("SimpleDenyList", simpleDenyList);
         bool newDeploy = _deploy2(initCode, "");
         _registerIfNew(newDeploy, "SimpleDenyList", simpleDenyList, registry, ABoostRegistry.RegistryType.ALLOW_LIST);
-    }}
+    }
+}

--- a/packages/evm/script/solidity/Util.s.sol
+++ b/packages/evm/script/solidity/Util.s.sol
@@ -18,12 +18,8 @@ contract ScriptUtils is Script {
     function _deploy2(bytes memory deployCode, bytes memory args) internal returns (bool) {
         bytes32 salt = keccak256(bytes(vm.envString("BOOST_DEPLOYMENT_SALT")));
         bytes32 bytecodeHash = keccak256(abi.encodePacked(deployCode, args));
-        address computedAddress = address(uint160(uint256(keccak256(abi.encodePacked(
-            bytes1(0xff),
-            CREATE2_FACTORY,
-            salt,
-            bytecodeHash
-        )))));
+        address computedAddress =
+            address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), CREATE2_FACTORY, salt, bytecodeHash)))));
 
         // Check if the address already has code deployed
         uint256 codeSize;
@@ -78,8 +74,14 @@ contract ScriptUtils is Script {
         return string(abi.encodePacked(vm.projectRoot(), "/deploys/", vm.toString(block.chainid), ".json"));
     }
 
-    function _registerIfNew(bool isNew, string memory contractName, address deployedAddress, BoostRegistry registry, BoostRegistry.RegistryType registryType) internal {
-        if(isNew) {
+    function _registerIfNew(
+        bool isNew,
+        string memory contractName,
+        address deployedAddress,
+        BoostRegistry registry,
+        BoostRegistry.RegistryType registryType
+    ) internal {
+        if (isNew) {
             vm.broadcast();
             registry.register(registryType, contractName, deployedAddress);
         }

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -564,7 +564,8 @@ contract BoostCoreTest is Test {
                         asset: address(mockERC20),
                         strategy: AERC20Incentive.Strategy.POOL,
                         reward: 1 ether,
-                        limit: 100
+                        limit: 100,
+                        manager: address(budget)
                     })
                 )
             });

--- a/packages/evm/test/e2e/EndToEndBasic.t.sol
+++ b/packages/evm/test/e2e/EndToEndBasic.t.sol
@@ -144,6 +144,15 @@ contract EndToEndBasic is Test {
 
         // - Max Participants == 5
         assertEq(boost.maxParticipants, 5);
+
+        // - ClawbackFromIncentive
+        // reverts on underflow
+        vm.expectRevert();
+        budget.clawbackFromIncentive(boost.incentives[0], abi.encode(500 ether + 1));
+
+        // can clawback funds from incentive
+        budget.clawbackFromIncentive(boost.incentives[0], abi.encode(500 ether));
+        assertEq(erc20.balanceOf(address(budget)), 500 ether);
     }
 
     /// @notice As a user, I want to complete a Boost so that I can earn the rewards.

--- a/packages/evm/test/e2e/EndToEndBasic.t.sol
+++ b/packages/evm/test/e2e/EndToEndBasic.t.sol
@@ -301,7 +301,7 @@ contract EndToEndBasic is Test {
                 )
             ),
             // "... of '100 ERC20' with a max of 5 participants"
-            parameters: abi.encode(erc20, AERC20Incentive.Strategy.POOL, 100 ether, 5)
+            parameters: abi.encode(erc20, AERC20Incentive.Strategy.POOL, 100 ether, 5, address(budget))
         });
 
         return core.createBoost(

--- a/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
+++ b/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
@@ -33,7 +33,7 @@ import {ERC20VariableIncentive} from "contracts/incentives/ERC20VariableIncentiv
 
 import {AValidator} from "contracts/validators/AValidator.sol";
 
-contract EndToEndSigner is Test, OwnableRoles {
+contract EndToEndSignerValidator is Test, OwnableRoles {
     BoostRegistry public registry = new BoostRegistry();
     address fee_recipient = address(1);
     BoostCore public core = new BoostCore(registry, fee_recipient);
@@ -264,7 +264,7 @@ contract EndToEndSigner is Test, OwnableRoles {
             // "... of '5 ERC20'"
             //address asset_, uint256 reward_, uint256 limit_
             // reward (second param) is unused
-            parameters: abi.encode(erc20, rewardAmount, incentiveLimitAmount)
+            parameters: abi.encode(erc20, rewardAmount, incentiveLimitAmount, address(budget))
         });
 
         return core.createBoost(

--- a/packages/evm/test/incentives/CGDAIncentive.t.sol
+++ b/packages/evm/test/incentives/CGDAIncentive.t.sol
@@ -31,7 +31,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(budget)
                 })
             )
         );
@@ -51,7 +52,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(budget)
                 })
             )
         );
@@ -82,7 +84,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(budget)
                 })
             )
         );
@@ -100,7 +103,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 0, // Invalid initialReward
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(budget)
                 })
             )
         );
@@ -118,7 +122,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 11 ether, // initialReward greater than totalBudget
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(budget)
                 })
             )
         );
@@ -156,6 +161,7 @@ contract CGDAIncentiveTest is Test {
     }
 
     function test_claim_OutOfBudget() public {
+        hoax(address(budget));
         incentive.clawback(
             abi.encode(
                 AIncentive.ClawbackPayload({
@@ -258,6 +264,7 @@ contract CGDAIncentiveTest is Test {
 
         bytes memory reclaimPayload =
             abi.encode(AIncentive.ClawbackPayload({target: address(0xdeadbeef), data: abi.encode(2 ether)}));
+        hoax(address(budget));
         incentive.clawback(reclaimPayload);
 
         assertEq(incentive.currentReward(), 0.25 ether);
@@ -293,7 +300,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(budget)
                 })
             )
         );

--- a/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
@@ -129,7 +129,14 @@ contract ERC20VariableIncentiveTest is Test {
 
     function testPreflight() public view {
         bytes memory preflightPayload = incentive.preflight(
-            abi.encode(ERC20VariableIncentive.InitPayload({asset: address(mockAsset), reward: 1 ether, limit: 5 ether}))
+            abi.encode(
+                ERC20VariableIncentive.InitPayload({
+                    asset: address(mockAsset),
+                    reward: 1 ether,
+                    limit: 5 ether,
+                    manager: address(budget)
+                })
+            )
         );
 
         ABudget.Transfer memory transfer = abi.decode(preflightPayload, (ABudget.Transfer));
@@ -149,6 +156,7 @@ contract ERC20VariableIncentiveTest is Test {
         // Reclaim some tokens
         bytes memory reclaimPayload =
             abi.encode(AIncentive.ClawbackPayload({target: address(this), data: abi.encode(2 ether)}));
+        hoax(address(budget));
         incentive.clawback(reclaimPayload);
 
         // Check the balance and limit
@@ -203,8 +211,10 @@ contract ERC20VariableIncentiveTest is Test {
         incentive.initialize(_initPayload(asset, reward, limit));
     }
 
-    function _initPayload(address asset, uint256 reward, uint256 limit) internal pure returns (bytes memory) {
-        return abi.encode(ERC20VariableIncentive.InitPayload({asset: asset, reward: reward, limit: limit}));
+    function _initPayload(address asset, uint256 reward, uint256 limit) internal view returns (bytes memory) {
+        return abi.encode(
+            ERC20VariableIncentive.InitPayload({asset: asset, reward: reward, limit: limit, manager: address(budget)})
+        );
     }
 
     function _makeFungibleTransfer(ABudget.AssetType assetType, address asset, address target, uint256 value)

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -818,6 +818,7 @@ describe('BoostCore', () => {
       strategy: StrategyType.POOL,
       reward: 1n,
       limit: 1n,
+      manager: budgets.budget.assertValidAddress(),
     });
     const boost = await freshBoost(fixtures, {
       budget: budgets.budget,

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -57,6 +57,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -101,6 +102,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -184,6 +186,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -235,6 +238,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -255,6 +259,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -297,6 +302,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -322,6 +328,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -364,6 +371,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -389,6 +397,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -414,6 +423,7 @@ describe('BoostCore', () => {
       reward: parseEther('1'),
       limit: 100n,
       strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
     });
     const _boost = await core.createBoost({
       budget: budget,
@@ -473,6 +483,7 @@ describe('BoostCore', () => {
       reward: 1n,
       limit: 10n,
       strategy: StrategyType.POOL,
+      manager: budget.assertValidAddress(),
     });
     // const erc1155Incentive = core.ERC1155Incentive({
     //   asset: erc1155.assertValidAddress(),
@@ -487,6 +498,7 @@ describe('BoostCore', () => {
       totalBudget: 10n,
       rewardBoost: 1n,
       rewardDecay: 1n,
+      manager: budget.assertValidAddress(),
     });
     const allowListIncentive = core.AllowListIncentive({
       allowList: allowList.assertValidAddress(),
@@ -623,6 +635,7 @@ describe('BoostCore', () => {
       rewardDecay: 0n,
       rewardBoost: 0n,
       totalBudget: 0n,
+      manager: zeroAddress,
     });
     expect(cgdaIncentive._config).toEqual(defaultOptions.config);
     expect(cgdaIncentive._account).toEqual(defaultOptions.account);
@@ -699,6 +712,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -749,6 +763,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });
@@ -777,6 +792,7 @@ describe('BoostCore', () => {
           reward: parseEther('1'),
           limit: 100n,
           strategy: StrategyType.POOL,
+          manager: budget.assertValidAddress(),
         }),
       ],
     });

--- a/packages/sdk/src/Incentives/CGDAIncentive.test.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.test.ts
@@ -1,6 +1,6 @@
 import { readMockErc20BalanceOf } from '@boostxyz/evm';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { isAddress, pad, parseEther } from 'viem';
+import { isAddress, pad, parseEther, zeroAddress } from 'viem';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import { accounts } from '@boostxyz/test/accounts';
 import {
@@ -31,6 +31,7 @@ describe('CGDAIncentive', () => {
       totalBudget: 10n,
       rewardBoost: 1n,
       rewardDecay: 1n,
+      manager: budgets.budget.address || zeroAddress 
     });
     await action.deploy();
     expect(isAddress(action.assertValidAddress())).toBe(true);
@@ -47,6 +48,7 @@ describe('CGDAIncentive', () => {
       totalBudget: 10n,
       rewardBoost: 1n,
       rewardDecay: 1n,
+      manager: budgets.budget.assertValidAddress(),
     });
     const boost = await freshBoost(fixtures, {
       budget: budgets.budget,
@@ -92,6 +94,7 @@ describe('CGDAIncentive', () => {
       totalBudget: 10n,
       rewardBoost: 1n,
       rewardDecay: 1n,
+      manager: budgets.budget.address || zeroAddress 
     });
     const boost = await freshBoost(fixtures, {
       budget: budgets.budget,

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -75,6 +75,12 @@ export interface CGDAIncentivePayload {
    * @type {bigint}
    */
   totalBudget: bigint;
+  /**
+   * The entity that can `clawback` funds
+   *
+   * @type {Address}
+   */
+  manager: Address;
 }
 
 /**
@@ -456,6 +462,7 @@ export function prepareCGDAIncentivePayload({
   rewardDecay,
   rewardBoost,
   totalBudget,
+  manager,
 }: CGDAIncentivePayload) {
   return encodeAbiParameters(
     [
@@ -464,7 +471,8 @@ export function prepareCGDAIncentivePayload({
       { type: 'uint256', name: 'rewardDecay' },
       { type: 'uint256', name: 'rewardBoost' },
       { type: 'uint256', name: 'totalBudget' },
+      { type: 'address', name: 'manager' },
     ],
-    [asset, initialReward, rewardDecay, rewardBoost, totalBudget],
+    [asset, initialReward, rewardDecay, rewardBoost, totalBudget, manager],
   );
 }

--- a/packages/sdk/src/Incentives/ERC20Incentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.test.ts
@@ -32,6 +32,7 @@ describe('ERC20Incentive', () => {
       strategy: StrategyType.POOL,
       reward: 1n,
       limit: 1n,
+      manager: zeroAddress,
     });
     await action.deploy();
     expect(isAddress(action.assertValidAddress())).toBe(true);
@@ -47,6 +48,7 @@ describe('ERC20Incentive', () => {
       strategy: StrategyType.POOL,
       reward: 1n,
       limit: 1n,
+      manager: budgets.budget.assertValidAddress(),
     });
     const boost = await freshBoost(fixtures, {
       budget: budgets.budget,
@@ -90,6 +92,7 @@ describe('ERC20Incentive', () => {
       strategy: StrategyType.POOL,
       reward: 1n,
       limit: 1n,
+      manager: budgets.budget.assertValidAddress(),
     });
     const boost = await freshBoost(fixtures, {
       budget: budgets.budget,

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -76,6 +76,12 @@ export interface ERC20IncentivePayload {
    * @type {bigint}
    */
   limit: bigint;
+  /**
+   * The entity that can `clawback` funds
+   *
+   * @type {Address}
+   */
+  manager: Address;
 }
 
 /**
@@ -471,6 +477,7 @@ export function prepareERC20IncentivePayload({
   strategy,
   reward,
   limit,
+  manager,
 }: ERC20IncentivePayload) {
   return encodeAbiParameters(
     [
@@ -478,7 +485,8 @@ export function prepareERC20IncentivePayload({
       { type: 'uint8', name: 'strategy' },
       { type: 'uint256', name: 'reward' },
       { type: 'uint256', name: 'limit' },
+      { type: 'address', name: 'manager' },
     ],
-    [asset, strategy, reward, limit],
+    [asset, strategy, reward, limit, manager],
   );
 }

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.test.ts
@@ -31,6 +31,7 @@ describe('ERC20VariableIncentive', () => {
       asset: zeroAddress,
       reward: 1n,
       limit: 1n,
+      manager: zeroAddress,
     });
     await action.deploy();
     expect(isAddress(action.assertValidAddress())).toBe(true);
@@ -47,6 +48,7 @@ describe('ERC20VariableIncentive', () => {
         asset: budgets.erc20.assertValidAddress(),
         reward: 1n,
         limit: 1n,
+        manager: zeroAddress,
       },
     );
     const boost = await freshBoost(fixtures, {
@@ -93,6 +95,7 @@ describe('ERC20VariableIncentive', () => {
         asset: budgets.erc20.assertValidAddress(),
         reward: 1n,
         limit: 1n,
+        manager: zeroAddress,
       },
     );
     const boost = await freshBoost(fixtures, {

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -62,6 +62,12 @@ export interface ERC20VariableIncentivePayload {
    * @type {bigint}
    */
   limit: bigint;
+  /**
+   * The entity that can `clawback` funds
+   *
+   * @type {Address}
+   */
+  manager: Address;
 }
 
 /**
@@ -410,13 +416,15 @@ export function prepareERC20VariableIncentivePayload({
   asset,
   reward,
   limit,
+  manager,
 }: ERC20VariableIncentivePayload) {
   return encodeAbiParameters(
     [
       { type: 'address', name: 'asset' },
       { type: 'uint256', name: 'reward' },
       { type: 'uint256', name: 'limit' },
+      { type: 'address', name: 'manager' },
     ],
-    [asset, reward, limit],
+    [asset, reward, limit, manager],
   );
 }

--- a/packages/sdk/src/Incentives/Incentive.test.ts
+++ b/packages/sdk/src/Incentives/Incentive.test.ts
@@ -49,6 +49,7 @@ describe('Incentive', () => {
       totalBudget: 10n,
       rewardBoost: 1n,
       rewardDecay: 1n,
+      manager: zeroAddress,
     });
     await incentive.deploy();
     expect(
@@ -65,6 +66,7 @@ describe('Incentive', () => {
       strategy: StrategyType.POOL,
       reward: 1n,
       limit: 10n,
+      manager: zeroAddress,
     });
     await incentive.deploy();
     expect(
@@ -80,6 +82,7 @@ describe('Incentive', () => {
       asset: zeroAddress,
       reward: 1n,
       limit: 10n,
+      manager: zeroAddress,
     });
     await incentive.deploy();
     expect(


### PR DESCRIPTION
This change enables budgets to reclaim funds from incentives they have seeded.
Transfers are not safety-checked because this is effectively a reverse transfer.
In other words, it is assumed that a budget that deployed those funds can
safely accept them without loss.

Additionally, this function ensures funds can only be returned to the budget.
This design decision allows for Managers and not just owners of budgets to
call this function.

This is all implemented on the Incentive side by utilizing `RBAC` and
auth-gating the  incentive `clawback` function on the `MANAGER_ROLE`.
BoostCore is still set as the owner so it can call the incentive `claim`
function.
