### PR TITLE
chore(evm): move hardhat cache from `cache` to `cache_hh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ packages/evm/deploys/componentInterfaces.json
 
 # evm package
 packages/evm/cache_forge/
+packages/evm/cache_hh/
 packages/evm/out/
 packages/evm/artifacts/
 

--- a/packages/evm/hardhat_build.config.cjs
+++ b/packages/evm/hardhat_build.config.cjs
@@ -15,4 +15,7 @@ module.exports = {
       runs: 10_000,
     },
   },
+  paths: {
+    cache: './cache_hh',
+  },
 };


### PR DESCRIPTION
This change fixes some strange caching behavior with foundry. I think
foundry greedily checks this cache folder if it exists, regardless of
its config, so moving the hardhat cache should improve some foundry
performance when working locally.
