### PR TITLE
[BOOST-4831] feat: add anyActionParam

### DIFF
--- a/.changeset/fluffy-dolphins-dress.md
+++ b/.changeset/fluffy-dolphins-dress.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+create and validate `anyActionParameter`


### PR DESCRIPTION
### Description
We want to be able to use `anyActionParam()` when we want to define a basic action parameter that allows for easy validation. An example use case is if we want to validate that a user called a function, but don't care about any parameters

I decided against making the Criteria optional, as it does kind of make some of the type checking throughout the EventAction.ts file messy

fix #206 