### PR TITLE
[ADHOC]: add BoostCreated and BoostClaimed events to signatures

### DIFF
--- a/.changeset/real-planes-ring.md
+++ b/.changeset/real-planes-ring.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/signatures": minor
+---
+
+add BoostCreated and BoostClaimed events

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -9,6 +9,8 @@
   "Minted(uint8,address,uint256,uint256)",
   "Minted(address indexed,uint8,uint8,address indexed,(uint32,uint256,address,uint32,uint32,uint32,address,bool,uint256,uint256,uint256,uint256,uint256),uint256 indexed)",
   "ZoraTimedSaleStrategyRewards(address indexed,uint256 indexed,address,uint256,address,uint256,address,uint256,address,uint256,address,uint256)",
+  "BoostClaimed(uint256 indexed,uint256 indexed,address indexed,address,bytes)",
+  "BoostCreated(uint256 indexed,address indexed,address indexed,uint256,address,address,address)",
   "// Test signatures",
   "InfoIndexed(address indexed,string indexed)",
   "Info(address,string)"

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -11,6 +11,7 @@
   "ZoraTimedSaleStrategyRewards(address indexed,uint256 indexed,address,uint256,address,uint256,address,uint256,address,uint256,address,uint256)",
   "BoostClaimed(uint256 indexed,uint256 indexed,address indexed,address,bytes)",
   "BoostCreated(uint256 indexed,address indexed,address indexed,uint256,address,address,address)",
+  "SecondaryBuy(address indexed,address indexed,address indexed,uint256,uint256)",
   "// Test signatures",
   "InfoIndexed(address indexed,string indexed)",
   "Info(address,string)"


### PR DESCRIPTION
### Description
- add BoostCreated and BoostClaimed events to event signatures.
- add SecondaryBuy event (Zora Secondary)

💔 Thank you!
