### PR TITLE
[ADHOC] Fix SignerValidator Signature

### DIFF
--- a/.changeset/ten-horses-sleep.md
+++ b/.changeset/ten-horses-sleep.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+Replace signTypedData util with PrivateKeyAccount's signTypedData

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -603,9 +603,8 @@ export async function prepareSignerValidatorClaimDataPayload({
     },
   };
 
-  const trustedSignature = await signTypedData({
+  const trustedSignature = await signer.privateKey.signTypedData({
     ...typedData,
-    privateKey: signer.key,
   });
 
   // Prepare the claim data payload using the new helper


### PR DESCRIPTION
### Description
Got the following error when trying to generate a signature:
```
Error: private key must be 32 bytes, hex or bigint, not string
```

This happens because the `signTypedData` expects a private key, which we cannot access. It seemed like we tried to pass in `signer.key`, but that is the public key