### PR TITLE
[ADHOC] fix(sdk,EventAction): transactionSenderClaimant needs chainId, accept all GetTransactionParametters in validation

### DIFF
--- a/.changeset/great-roses-sort.md
+++ b/.changeset/great-roses-sort.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+must supply chainId in `transactionSenderClaimant`

--- a/.changeset/soft-schools-warn.md
+++ b/.changeset/soft-schools-warn.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+accept `GetTransactionParameters` in `ValidateActionStepParams` to fix retroactive Boost completion

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -223,12 +223,10 @@ export interface ActionStep {
  * @property {AbiEvent | AbiFunction} [abiItem] - Optional ABI item definition.
  * @property {EventLogs} [logs] - Event logs to validate against. Required if 'hash' is not provided.
  * @property {Hex} [hash] - Transaction hash to validate against. Required if 'logs' is not provided.
- * @property {number} [chainId] - Chain ID for the transaction.
  */
 export type ValidateActionStepParams = {
   knownSignatures: Record<Hex, AbiEvent | AbiFunction>;
   abiItem?: AbiEvent | AbiFunction;
-  chainId: number;
 } & ({ logs: EventLogs } | { hash: Hex });
 
 /**
@@ -526,7 +524,7 @@ export class EventAction extends DeployableTarget<
       if ('hash' in params) {
         const transaction = await getTransaction(this._config, {
           hash: params.hash,
-          chainId: params.chainId,
+          chainId: claimant.chainid,
         });
         return transaction.from;
       }
@@ -589,7 +587,7 @@ export class EventAction extends DeployableTarget<
     if (claimant.signatureType === SignatureType.FUNC && 'hash' in params) {
       const transaction = await getTransaction(this._config, {
         hash: params.hash,
-        chainId: params.chainId,
+        chainId: claimant.chainid,
       });
       if (!isAddressEqual(transaction.to!, claimant.targetContract)) return;
       let func: AbiFunction;
@@ -701,7 +699,7 @@ export class EventAction extends DeployableTarget<
 
       const receipt = await getTransactionReceipt(this._config, {
         hash: params.hash,
-        chainId: params.chainId,
+        chainId: actionStep.chainid,
       });
       const decodedLogs = receipt.logs.map((log) => {
         const { eventName, args } = decodeEventLog({
@@ -719,7 +717,7 @@ export class EventAction extends DeployableTarget<
       if ('hash' in params && 'chainId' in params) {
         const transaction = await getTransaction(this._config, {
           hash: params.hash,
-          chainId: params.chainId,
+          chainId: actionStep.chainid,
         });
         return this.isActionFunctionValid(actionStep, transaction, params);
       }
@@ -1281,8 +1279,9 @@ export function anyActionParameter(): Criteria {
  * - signature: Set to zeroHash (0x0000...0000)
  * - fieldIndex: Set to 255, indicating "any" field using CheatCodes enum
  * - targetContract: Set to zeroAddress (0x0000...0000)
- * - chainid: Set to 0, indicating it's valid for any chain
+ * - chainid:  The chain ID on which the transaction is sent, should match the chain ID for the action's {@link ActionStep}
  *
+ * @param {number} chainId - The chain ID on which the transaction is sent, should match the chain ID for the action's {@link ActionStep}
  * @returns {ActionClaimant} An ActionClaimant object representing the msg.sender
  *
  * @example
@@ -1295,12 +1294,12 @@ export function anyActionParameter(): Criteria {
  * };
  * await eventAction.deploy(payload);
  */
-export function transactionSenderClaimant(): ActionClaimant {
+export function transactionSenderClaimant(chainId: number): ActionClaimant {
   return {
     signatureType: SignatureType.EVENT,
     signature: zeroHash,
     fieldIndex: CheatCodes.TX_SENDER_CLAIMANT,
     targetContract: zeroAddress,
-    chainid: 0,
+    chainid: chainId,
   };
 }

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -578,14 +578,13 @@ export async function prepareSignerValidatorClaimDataPayload({
   claimant,
   boostId,
 }: SignerValidatorClaimDataParams): Promise<Hex> {
-  const domain = {
-    name: 'SignerValidator',
-    version: '1',
-    chainId: chainId,
-    verifyingContract: validator,
-  };
-  const typedData = {
-    domain,
+  const trustedSignature = await signer.privateKey.signTypedData({
+    domain: {
+      name: 'SignerValidator',
+      version: '1',
+      chainId: chainId,
+      verifyingContract: validator,
+    },
     types: {
       SignerValidatorData: [
         { name: 'boostId', type: 'uint256' },
@@ -601,10 +600,6 @@ export async function prepareSignerValidatorClaimDataPayload({
       claimant,
       incentiveData: incentiveData,
     },
-  };
-
-  const trustedSignature = await signer.privateKey.signTypedData({
-    ...typedData,
   });
 
   // Prepare the claim data payload using the new helper


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
- mandatory chainId in transactionSenderClaimant
- GetTransactionParameters in ValidateActionStepParams to fix retroactive boost validation

💔 Thank you!
