### PR TITLE
[ADHOC] feat: add OR_EQUAL filters to event action

### DIFF
--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -24,7 +24,9 @@ abstract contract AEventAction is AAction {
         GREATER_THAN,
         LESS_THAN,
         CONTAINS,
-        REGEX
+        REGEX,
+        GREATER_THAN_OR_EQUAL,
+        LESS_THAN_OR_EQUAL
     }
 
     enum PrimitiveType {

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -873,7 +873,7 @@ describe("validateFieldAgainstCriteria unit tests", () => {
 
   test("should throw UnrecognizedFilterTypeError for unrecognized filter type", () => {
     const mockCriteria = createMockCriteria(
-      6 as FilterType,
+      8 as FilterType,
       PrimitiveType.STRING,
       "0x74657374",
     ); // Decoded value: 'test'

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -72,6 +72,8 @@ export enum FilterType {
   LESS_THAN = 3,
   CONTAINS = 4,
   REGEX = 5,
+  GREATER_THAN_OR_EQUAL = 6,
+  LESS_THAN_OR_EQUAL = 7,
 }
 
 /**
@@ -908,10 +910,28 @@ export class EventAction extends DeployableTarget<
           criteria,
           fieldValue,
         });
+      case FilterType.GREATER_THAN_OR_EQUAL:
+        if (criteria.fieldType === PrimitiveType.UINT) {
+          return BigInt(fieldValue) >= BigInt(criteria.filterData);
+        }
+        throw new InvalidNumericalCriteriaError({
+          ...input,
+          criteria,
+          fieldValue,
+        });
 
       case FilterType.LESS_THAN:
         if (criteria.fieldType === PrimitiveType.UINT) {
           return BigInt(fieldValue) < BigInt(criteria.filterData);
+        }
+        throw new InvalidNumericalCriteriaError({
+          ...input,
+          criteria,
+          fieldValue,
+        });
+      case FilterType.LESS_THAN_OR_EQUAL:
+        if (criteria.fieldType === PrimitiveType.UINT) {
+          return BigInt(fieldValue) <= BigInt(criteria.filterData);
         }
         throw new InvalidNumericalCriteriaError({
           ...input,


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
Adds `GREATER_THAN_OR_EQUAL` and `LESS_THAN_OR_EQUAL` to `EventAction.sol` and `EventAction.ts`

This will require a redeployment

💔 Thank you!
