### PR TITLE
[ADHOC] Fix `DecodeLogTopicsMismatch` Error

### DIFF
--- a/.changeset/shaggy-moose-fry.md
+++ b/.changeset/shaggy-moose-fry.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fixes `DecodeLogTopicsMismatch` error


### PR DESCRIPTION
### Description
We try to decode the logs in a tx, but only pass in a specific set of abi. Since most txs have a ton of other events, viem throws a `DecodeLogTopicsMismatch` error

This PR adds a filter to those logs so that we only decode logs that we care about in the action step validation and action claimant