### PR TITLE
[ADHOC] fix(evm): ensure additional protocol fees can set fees per boost

### DIFF
--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -137,7 +137,7 @@ contract BoostCoreTest is Test {
                     validator: BoostLib.Target({isBase: true, instance: address(0), parameters: ""}),
                     allowList: allowList,
                     incentives: _makeIncentives(1),
-                    protocolFee: 500, // 5%
+                    protocolFee: 0,
                     maxParticipants: 10_000,
                     owner: address(1)
                 })

--- a/packages/evm/test/e2e/EndToEndBasic.t.sol
+++ b/packages/evm/test/e2e/EndToEndBasic.t.sol
@@ -151,7 +151,7 @@ contract EndToEndBasic is Test {
         // can clawback funds from incentive
         budget.clawbackFromTarget(address(core), abi.encode(500 ether), boostId, incentiveId);
         // Should recover the full budget including the protocol fee
-        assertEq(erc20.balanceOf(address(budget)), 550 ether);
+        assertEq(erc20.balanceOf(address(budget)), 600 ether);
     }
 
     /// @notice As a user, I want to complete a Boost so that I can earn the rewards.
@@ -229,7 +229,7 @@ contract EndToEndBasic is Test {
     function _when_I_allocate_assets_to_my_budget(ABudget budget) internal {
         // "When I allocate assets to my budget"
         // "And the asset is an ERC20 token"
-        erc20.approve(address(budget), 550 ether);
+        erc20.approve(address(budget), 600 ether);
         assertTrue(
             budget.allocate(
                 abi.encode(
@@ -237,15 +237,15 @@ contract EndToEndBasic is Test {
                         assetType: ABudget.AssetType.ERC20,
                         asset: address(erc20),
                         target: address(this),
-                        data: abi.encode(ABudget.FungiblePayload({amount: 550 ether}))
+                        data: abi.encode(ABudget.FungiblePayload({amount: 600 ether}))
                     })
                 )
             )
         );
 
         // "Then my budget's balance should reflect the transferred amount"
-        assertEq(erc20.balanceOf(address(budget)), 550 ether);
-        assertEq(budget.available(address(erc20)), 550 ether);
+        assertEq(erc20.balanceOf(address(budget)), 600 ether);
+        assertEq(budget.available(address(erc20)), 600 ether);
 
         // "When I allocate assets to my budget"
         // "And the asset is ETH"

--- a/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
+++ b/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
@@ -196,7 +196,7 @@ contract EndToEndSignerValidator is Test, OwnableRoles {
     function _when_I_allocate_assets_to_my_budget(ABudget budget) internal {
         // "When I allocate assets to my budget"
         // "And the asset is an ERC20 token"
-        erc20.approve(address(budget), 550 ether);
+        erc20.approve(address(budget), 600 ether);
         assertTrue(
             budget.allocate(
                 abi.encode(
@@ -204,15 +204,15 @@ contract EndToEndSignerValidator is Test, OwnableRoles {
                         assetType: ABudget.AssetType.ERC20,
                         asset: address(erc20),
                         target: address(this),
-                        data: abi.encode(ABudget.FungiblePayload({amount: 550 ether}))
+                        data: abi.encode(ABudget.FungiblePayload({amount: 600 ether}))
                     })
                 )
             )
         );
 
         // "Then my budget's balance should reflect the transferred amount"
-        assertEq(erc20.balanceOf(address(budget)), 550 ether);
-        assertEq(budget.available(address(erc20)), 550 ether);
+        assertEq(erc20.balanceOf(address(budget)), 600 ether);
+        assertEq(budget.available(address(erc20)), 600 ether);
 
         // "When I allocate assets to my budget"
         // "And the asset is ETH"

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -78,7 +78,7 @@ describe("BoostCore", () => {
     const { core } = fixtures;
     const { budget, erc20 } = budgets;
     const boost = await core.createBoost({
-      protocolFee: 1n,
+      protocolFee: 0n,
       maxParticipants: 100n,
       budget: budget,
       action: core.EventAction(
@@ -160,7 +160,7 @@ describe("BoostCore", () => {
     const { core } = fixtures;
     const { budget, erc20 } = budgets;
     const _boost = await core.createBoost({
-      protocolFee: 1n,
+      protocolFee: 0n,
       maxParticipants: 100n,
       budget: budget,
       action: core.EventAction(
@@ -188,7 +188,7 @@ describe("BoostCore", () => {
       ],
     });
     const boost = await core.readBoost(_boost.id);
-    expect(boost.protocolFee).toBe(1001n);
+    expect(boost.protocolFee).toBe(1000n);
     expect(boost.maxParticipants).toBe(100n);
     expect(boost.budget).toBe(_boost.budget.assertValidAddress());
     expect(boost.action).toBe(_boost.action.assertValidAddress());
@@ -203,7 +203,7 @@ describe("BoostCore", () => {
     const { core } = fixtures;
     const { budget, erc20 } = budgets;
     const _boost = await core.createBoost({
-      protocolFee: 1n,
+      protocolFee: 0n,
       maxParticipants: 100n,
       budget: budget,
       action: core.EventAction(
@@ -234,7 +234,7 @@ describe("BoostCore", () => {
     const { core } = fixtures;
     const { budget, erc20 } = budgets;
     const simulated = await core.simulateCreateBoost({
-      protocolFee: 1n,
+      protocolFee: 0n,
       maxParticipants: 100n,
       budget: budget,
       action: core.EventAction(
@@ -569,7 +569,7 @@ describe("BoostCore", () => {
     });
 
     await core.createBoost({
-      protocolFee: 1n,
+      protocolFee: 0n,
       maxParticipants: 100n,
       budget: budget,
       action: core.EventAction(
@@ -730,7 +730,7 @@ describe("BoostCore", () => {
     core.subscribe(subscription, { pollingInterval: 100 });
     const { budget, erc20 } = budgets;
     await core.createBoost({
-      protocolFee: 1n,
+      protocolFee: 0n,
       maxParticipants: 100n,
       budget: budget,
       action: core.EventAction(


### PR DESCRIPTION


🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
Fix to account for per-boost protocol fees. Most likely we will not use this but better to have it and not need it etc.
This PR will be passed off to the lead auditor as well.

💔 Thank you!
