### PR TITLE
[BOOST-4904] deprecate managedbudgetroles enum for roles

### DIFF
--- a/.changeset/lazy-cows-sip.md
+++ b/.changeset/lazy-cows-sip.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+deprecate ManagedBudgetRoles enum for RBAC Roles

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -28,7 +28,10 @@ import type {
   DeployableOptions,
   GenericDeployableParams,
 } from '../Deployable/Deployable';
-import { DeployableTargetWithRBAC } from '../Deployable/DeployableTargetWithRBAC';
+import {
+  DeployableTargetWithRBAC,
+  type Roles,
+} from '../Deployable/DeployableTargetWithRBAC';
 import {
   DeployableUnknownOwnerProvidedError,
   UnknownTransferPayloadSupplied,
@@ -71,9 +74,9 @@ export interface ManagedBudgetPayload {
   /**
    * List of roles to assign to the corresponding account by index.
    *
-   * @type {ManagedBudgetRoles[]}
+   * @type {Roles[]}
    */
-  roles: ManagedBudgetRoles[];
+  roles: Roles[];
 }
 
 /**
@@ -81,6 +84,7 @@ export interface ManagedBudgetPayload {
  * `MANAGER` can disburse funds.
  * `ADMIN` can additionally manage authorized users on the budget.
  *
+ * @deprecated use {@link Roles} instead
  * @export
  * @type {{ readonly MANAGER: 1n; readonly ADMIN_ROLE: 2n; }}
  * @enum {bigint}

--- a/test/src/helpers.ts
+++ b/test/src/helpers.ts
@@ -61,11 +61,11 @@ import {
   type LimitedSignerValidatorPayload,
   ManagedBudget,
   type ManagedBudgetPayload,
-  ManagedBudgetRoles,
   OpenAllowList,
   PointsIncentive,
   type PointsIncentivePayload,
   PrimitiveType,
+  Roles,
   SignatureType,
   SignerValidator,
   type SignerValidatorPayload,
@@ -779,7 +779,7 @@ export function freshManagedBudget(
           options.account.address,
           fixtures.core.assertValidAddress(),
         ],
-        roles: [ManagedBudgetRoles.ADMIN, ManagedBudgetRoles.MANAGER],
+        roles: [Roles.ADMIN, Roles.MANAGER],
       }),
     );
   };


### PR DESCRIPTION
### Description
- Deprecated `ManagedBudgetRoles` on the ManagedBudget in favour of the RBAC `Roles` enum. 
- Updates any references to `ManagedBudgetRoles` with `Roles`
