### PR TITLE
[ADHOC] fix(zora-mint): hh block config

### DIFF
--- a/examples/zora-mint/hardhat.config.cjs
+++ b/examples/zora-mint/hardhat.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
         url:
           'https://base-mainnet.g.alchemy.com/v2/' +
           process.env.VITE_ALCHEMY_API_KEY,
+        blockNumber: 17519193,
       },
     },
   },


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
This is working for me locally but want to make sure it works on remote. We should figure out why the reset isn't working as expected anymore. I'm getting current block when this isn't set in config after their most recent update.

💔 Thank you!
