### PR TITLE
[ADHOC] chore: force SDK release for the recent deployment

### DIFF
--- a/.changeset/popular-months-fail.md
+++ b/.changeset/popular-months-fail.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+Bump SDK to build in new contracts and release


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
Since EVM isn't a direct dep of SDK anymore the changeset didn't trigger an SDK release, adding a changeset to force it.
💔 Thank you!
