### PR TITLE
[ADHOC] refactor(sdk): use SimulateContractParameters instead of WriteContractParameters

### DIFF
--- a/.changeset/real-boxes-jump.md
+++ b/.changeset/real-boxes-jump.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+change WriteParams to use SimulateContractParameters under the hood, remove excessively huge generic typings

--- a/packages/sdk/src/Actions/ContractAction.ts
+++ b/packages/sdk/src/Actions/ContractAction.ts
@@ -119,9 +119,7 @@ export class ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async chainId(
-    params?: ReadParams<typeof contractActionAbi, 'chainId'>,
-  ) {
+  public async chainId(params?: ReadParams) {
     return await readContractActionChainId(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -138,7 +136,7 @@ export class ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
-  public async target(params?: ReadParams<typeof contractActionAbi, 'target'>) {
+  public async target(params?: ReadParams) {
     return await readContractActionTarget(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -156,9 +154,7 @@ export class ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
-  public async selector(
-    params?: ReadParams<typeof contractActionAbi, 'selector'>,
-  ) {
+  public async selector(params?: ReadParams) {
     return await readContractActionSelector(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -175,7 +171,7 @@ export class ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async value(params?: ReadParams<typeof contractActionAbi, 'value'>) {
+  public async value(params?: ReadParams) {
     return await readContractActionValue(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -193,10 +189,7 @@ export class ContractAction<
    * @param {?WriteParams} [params]
    * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
-  public async execute(
-    data: Hex,
-    params?: WriteParams<typeof contractActionAbi, 'execute'>,
-  ) {
+  public async execute(data: Hex, params?: WriteParams) {
     return await this.awaitResult(this.executeRaw(data, params));
   }
 
@@ -209,10 +202,7 @@ export class ContractAction<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
-  public async executeRaw(
-    data: Hex,
-    params?: WriteParams<typeof contractActionAbi, 'execute'>,
-  ) {
+  public async executeRaw(data: Hex, params?: WriteParams) {
     const { request, result } = await simulateContractActionExecute(
       this._config,
       {
@@ -236,10 +226,7 @@ export class ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
-  public async prepare(
-    calldata: Hex,
-    params?: ReadParams<typeof contractActionAbi, 'prepare'>,
-  ) {
+  public async prepare(calldata: Hex, params?: ReadParams) {
     return await readContractActionPrepare(this._config, {
       address: this.assertValidAddress(),
       args: [calldata],

--- a/packages/sdk/src/Actions/ERC721MintAction.ts
+++ b/packages/sdk/src/Actions/ERC721MintAction.ts
@@ -99,10 +99,7 @@ export class ERC721MintAction extends ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async validated(
-    token: bigint,
-    params?: ReadParams<typeof erc721MintActionAbi, 'validated'>,
-  ) {
+  public async validated(token: bigint, params?: ReadParams) {
     return await readErc721MintActionValidated(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -121,10 +118,7 @@ export class ERC721MintAction extends ContractAction<
    * @param {?WriteParams} [params]
    * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
-  public override async execute(
-    data: Hex,
-    params?: WriteParams<typeof erc721MintActionAbi, 'execute'>,
-  ) {
+  public override async execute(data: Hex, params?: WriteParams) {
     return await this.awaitResult(this.executeRaw(data, params));
   }
 
@@ -137,10 +131,7 @@ export class ERC721MintAction extends ContractAction<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
-  public override async executeRaw(
-    data: Hex,
-    params?: WriteParams<typeof erc721MintActionAbi, 'execute'>,
-  ) {
+  public override async executeRaw(data: Hex, params?: WriteParams) {
     const { request, result } = await simulateErc721MintActionExecute(
       this._config,
       {
@@ -164,10 +155,7 @@ export class ERC721MintAction extends ContractAction<
    * @param {?ReadParams} [params]
    * @returns {Promise<`0x${string}`>}
    */
-  public override async prepare(
-    data: Hex,
-    params?: ReadParams<typeof erc721MintActionAbi, 'prepare'>,
-  ) {
+  public override async prepare(data: Hex, params?: ReadParams) {
     return await readErc721MintActionPrepare(this._config, {
       address: this.assertValidAddress(),
       args: [data],
@@ -190,7 +178,7 @@ export class ERC721MintAction extends ContractAction<
   protected async validate(
     holder: Address,
     tokenId: bigint,
-    params?: WriteParams<typeof erc721MintActionAbi, 'validate'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.validateRaw(holder, tokenId, params));
   }
@@ -208,7 +196,7 @@ export class ERC721MintAction extends ContractAction<
   protected async validateRaw(
     holder: Address,
     tokenId: bigint,
-    params?: WriteParams<typeof erc721MintActionAbi, 'validate'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateErc721MintActionValidate(
       this._config,

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -13,7 +13,6 @@ import {
   type AbiFunction,
   AbiItem,
   type Address,
-  type ContractFunctionName,
   type GetLogsReturnType,
   type GetTransactionParameters,
   type Hex,
@@ -323,17 +322,6 @@ export interface EventActionPayloadRaw {
 export type EventLogs = GetLogsReturnType<AbiEvent, AbiEvent[], true>;
 
 /**
- * Getter params from the event action contract
- *
- * @export
- * @typedef {ReadEventActionParams}
- * @param {fnName} fnName - The getter function name
- */
-export type ReadEventActionParams<
-  fnName extends ContractFunctionName<typeof eventActionAbi, 'pure' | 'view'>,
-> = ReadParams<typeof eventActionAbi, fnName>;
-
-/**
  * A generic event action
  *
  * @export
@@ -382,10 +370,7 @@ export class EventAction extends DeployableTarget<
    * @param {?ReadEventActionParams<'getActionStep'>} [params]
    * @returns {Promise<ActionStep>}
    */
-  public async getActionStep(
-    index: number,
-    params?: ReadEventActionParams<'getActionStep'>,
-  ) {
+  public async getActionStep(index: number, params?: ReadParams) {
     const steps = await this.getActionSteps(params);
     return steps.at(index);
   }
@@ -398,9 +383,7 @@ export class EventAction extends DeployableTarget<
    * @param {?ReadEventActionParams<'getActionSteps'>} [params]
    * @returns {Promise<ActionStep[]>}
    */
-  public async getActionSteps(
-    params?: ReadEventActionParams<'getActionSteps'>,
-  ) {
+  public async getActionSteps(params?: ReadParams) {
     const steps = (await readEventActionGetActionSteps(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -418,9 +401,7 @@ export class EventAction extends DeployableTarget<
    * @param {?ReadEventActionParams<'getActionStepsCount'>} [params]
    * @returns {Promise<bigint>}
    */
-  public async getActionStepsCount(
-    params?: ReadEventActionParams<'getActionStepsCount'>,
-  ) {
+  public async getActionStepsCount(params?: ReadParams) {
     const steps = await this.getActionSteps(params);
     return steps.length;
   }
@@ -433,9 +414,7 @@ export class EventAction extends DeployableTarget<
    * @param {?ReadEventActionParams<'getActionClaimant'>} [params]
    * @returns {Promise<ActionClaimant>}
    */
-  public async getActionClaimant(
-    params?: ReadEventActionParams<'getActionClaimant'>,
-  ): Promise<ActionClaimant> {
+  public async getActionClaimant(params?: ReadParams): Promise<ActionClaimant> {
     const result = (await readEventActionGetActionClaimant(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -453,10 +432,7 @@ export class EventAction extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<readonly [boolean, `0x${string}`]>}
    */
-  public async execute(
-    data: Hex,
-    params?: WriteParams<typeof eventActionAbi, 'execute'>,
-  ) {
+  public async execute(data: Hex, params?: WriteParams) {
     return await this.awaitResult(this.executeRaw(data, params));
   }
 
@@ -469,10 +445,7 @@ export class EventAction extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: readonly [boolean, `0x${string}`]; }>}
    */
-  public async executeRaw(
-    data: Hex,
-    params?: WriteParams<typeof eventActionAbi, 'execute'>,
-  ) {
+  public async executeRaw(data: Hex, params?: WriteParams) {
     const { request, result } = await simulateEventActionExecute(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),

--- a/packages/sdk/src/AllowLists/SimpleAllowList.ts
+++ b/packages/sdk/src/AllowLists/SimpleAllowList.ts
@@ -119,9 +119,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>} - The address of the owner
    */
-  public async owner(
-    params?: ReadParams<typeof simpleAllowListAbi, 'owner'>,
-  ): Promise<Address> {
+  public async owner(params?: ReadParams): Promise<Address> {
     return await readSimpleAllowListOwner(this._config, {
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -142,7 +140,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    */
   public async isAllowed(
     address: Address,
-    params?: ReadParams<typeof simpleAllowListAbi, 'setAllowed'>,
+    params?: ReadParams,
   ): Promise<boolean> {
     return await readSimpleAllowListIsAllowed(this._config, {
       address: this.assertValidAddress(),
@@ -167,7 +165,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
   public async setAllowed(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof simpleAllowListAbi, 'setAllowed'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.setAllowedRaw(addresses, allowed, params),
@@ -188,7 +186,7 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
   public async setAllowedRaw(
     addresses: Address[],
     allowed: boolean[],
-    params?: ReadParams<typeof simpleAllowListAbi, 'setAllowed'>,
+    params?: ReadParams,
   ) {
     const { request, result } = await simulateSimpleAllowListSetAllowed(
       this._config,

--- a/packages/sdk/src/AllowLists/SimpleDenyList.ts
+++ b/packages/sdk/src/AllowLists/SimpleDenyList.ts
@@ -111,9 +111,7 @@ export class SimpleDenyList<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>} - The address of the owner
    */
-  public async owner(
-    params?: ReadParams<typeof simpleDenyListAbi, 'owner'>,
-  ): Promise<Address> {
+  public async owner(params?: ReadParams): Promise<Address> {
     return await readSimpleAllowListOwner(this._config, {
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -134,7 +132,7 @@ export class SimpleDenyList<
    */
   public async isAllowed(
     address: Address,
-    params?: ReadParams<typeof simpleDenyListAbi, 'isAllowed'>,
+    params?: ReadParams,
   ): Promise<boolean> {
     return await readSimpleDenyListIsAllowed(this._config, {
       address: this.assertValidAddress(),
@@ -158,7 +156,7 @@ export class SimpleDenyList<
   public async setDenied(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof simpleDenyListAbi, 'setDenied'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.setDeniedRaw(addresses, allowed, params),
@@ -178,7 +176,7 @@ export class SimpleDenyList<
   public async setDeniedRaw(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof simpleDenyListAbi, 'setDenied'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateSimpleDenyListSetDenied(
       this._config,

--- a/packages/sdk/src/Auth/PassthroughAuth.ts
+++ b/packages/sdk/src/Auth/PassthroughAuth.ts
@@ -44,10 +44,7 @@ export class PassthroughAuth extends Deployable<
 > {
   public override readonly abi = passthroughAuthAbi;
 
-  public async isAuthorized(
-    address: Address,
-    params?: ReadParams<typeof passthroughAuthAbi, 'isAuthorized'>,
-  ) {
+  public async isAuthorized(address: Address, params?: ReadParams) {
     return await readPassthroughAuthIsAuthorized(this._config, {
       address: this.assertValidAddress(),
       args: [address],

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -1,6 +1,5 @@
 import {
   boostCoreAbi,
-  type iAuthAbi,
   readBoostCoreCreateBoostAuth,
   readBoostCoreGetBoost,
   readBoostCoreGetBoostCount,
@@ -336,7 +335,7 @@ export class BoostCore extends Deployable<
   ) {
     const [payload, options] =
       this.validateDeploymentConfig<CreateBoostPayload>(_boostPayload);
-    const desiredChainId = _params?.chain?.id || _params?.chainId;
+    const desiredChainId = _params?.chainId;
     const { chainId, address: coreAddress } = assertValidAddressByChainId(
       options.config,
       this.addresses,
@@ -406,7 +405,7 @@ export class BoostCore extends Deployable<
   ) {
     const [payload, options] =
       this.validateDeploymentConfig<CreateBoostPayload>(_boostPayload);
-    const desiredChainId = _params?.chain?.id || _params?.chainId;
+    const desiredChainId = _params?.chainId;
     const { chainId, address: coreAddress } = assertValidAddressByChainId(
       options.config,
       this.addresses,
@@ -657,7 +656,7 @@ export class BoostCore extends Deployable<
         ...assertValidAddressByChainId(
           this._config,
           this.addresses,
-          params?.chain?.id || params?.chainId,
+          params?.chainId,
         ),
         args: [boostId, incentiveId, referrer, data],
         ...this.optionallyAttachAccount(),
@@ -729,7 +728,7 @@ export class BoostCore extends Deployable<
         ...assertValidAddressByChainId(
           this._config,
           this.addresses,
-          params?.chain?.id || params?.chainId,
+          params?.chainId,
         ),
         args: [boostId, incentiveId, referrer, data, claimant],
         ...this.optionallyAttachAccount(),

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -332,7 +332,7 @@ export class BoostCore extends Deployable<
    */
   public async createBoost(
     _boostPayload: CreateBoostPayload,
-    _params?: WriteParams<typeof boostCoreAbi, 'createBoost'>,
+    _params?: WriteParams,
   ) {
     const [payload, options] =
       this.validateDeploymentConfig<CreateBoostPayload>(_boostPayload);
@@ -402,7 +402,7 @@ export class BoostCore extends Deployable<
    */
   public async simulateCreateBoost(
     _boostPayload: CreateBoostPayload,
-    _params?: WriteParams<typeof boostCoreAbi, 'createBoost'>,
+    _params?: WriteParams,
   ) {
     const [payload, options] =
       this.validateDeploymentConfig<CreateBoostPayload>(_boostPayload);
@@ -625,7 +625,7 @@ export class BoostCore extends Deployable<
     incentiveId: bigint,
     address: Address,
     data: Hex,
-    params?: WriteParams<typeof boostCoreAbi, 'claimIncentive'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.claimIncentiveRaw(boostId, incentiveId, address, data, params),
@@ -649,7 +649,7 @@ export class BoostCore extends Deployable<
     incentiveId: bigint,
     referrer: Address,
     data: Hex,
-    params?: WriteParams<typeof boostCoreAbi, 'claimIncentive'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateBoostCoreClaimIncentive(
       this._config,
@@ -688,7 +688,7 @@ export class BoostCore extends Deployable<
     referrer: Address,
     data: Hex,
     claimant: Address,
-    params?: WriteParams<typeof boostCoreAbi, 'claimIncentiveFor'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.claimIncentiveForRaw(
@@ -721,7 +721,7 @@ export class BoostCore extends Deployable<
     referrer: Address,
     data: Hex,
     claimant: Address,
-    params?: WriteParams<typeof boostCoreAbi, 'claimIncentiveFor'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateBoostCoreClaimIncentiveFor(
       this._config,
@@ -753,7 +753,7 @@ export class BoostCore extends Deployable<
    */
   public async readBoost(
     _id: string | bigint,
-    params?: ReadParams<typeof boostCoreAbi, 'getBoost'>,
+    params?: ReadParams,
   ): Promise<RawBoost> {
     try {
       let id: bigint;
@@ -789,10 +789,7 @@ export class BoostCore extends Deployable<
    * @returns {Promise<Boost>}
    * @throws {@link BoostNotFoundError}
    */
-  public async getBoost(
-    _id: string | bigint,
-    params?: ReadParams<typeof boostCoreAbi, 'getBoost'>,
-  ) {
+  public async getBoost(_id: string | bigint, params?: ReadParams) {
     let id: bigint;
     if (typeof _id === 'string') {
       id = BigInt(_id);
@@ -836,9 +833,7 @@ export class BoostCore extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async getBoostCount(
-    params?: ReadParams<typeof boostCoreAbi, 'getBoostCount'>,
-  ) {
+  public async getBoostCount(params?: ReadParams) {
     return await readBoostCoreGetBoostCount(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -859,13 +854,12 @@ export class BoostCore extends Deployable<
    * @async
    * @param {Address} address
    * @param {?ReadParams &
-   *       ReadParams<typeof iAuthAbi, 'isAuthorized'>} [params]
+   *       ReadParams} [params]
    * @returns {Promise<boolean>}
    */
   public async isAuthorized(
     address: Address,
-    params?: ReadParams<typeof boostCoreAbi, 'createBoostAuth'> &
-      ReadParams<typeof iAuthAbi, 'isAuthorized'>,
+    params?: ReadParams & ReadParams,
   ) {
     const auth = await this.createBoostAuth(params);
     return readIAuthIsAuthorized(this._config, {
@@ -885,9 +879,7 @@ export class BoostCore extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async createBoostAuth(
-    params?: ReadParams<typeof boostCoreAbi, 'createBoostAuth'>,
-  ) {
+  public async createBoostAuth(params?: ReadParams) {
     return await readBoostCoreCreateBoostAuth(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -910,10 +902,7 @@ export class BoostCore extends Deployable<
    * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
-  public async setCreateBoostAuth(
-    auth: Auth,
-    params?: WriteParams<typeof boostCoreAbi, 'setCreateBoostAuth'>,
-  ) {
+  public async setCreateBoostAuth(auth: Auth, params?: WriteParams) {
     return await this.awaitResult(
       this.setCreateBoostAuthRaw(auth.assertValidAddress(), {
         ...params,
@@ -930,10 +919,7 @@ export class BoostCore extends Deployable<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
-  public async setCreateBoostAuthRaw(
-    address: Address,
-    params?: WriteParams<typeof boostCoreAbi, 'setCreateBoostAuth'>,
-  ) {
+  public async setCreateBoostAuthRaw(address: Address, params?: WriteParams) {
     const { request, result } = await simulateBoostCoreSetCreateBoostAuth(
       this._config,
       {
@@ -960,9 +946,7 @@ export class BoostCore extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {unknown}
    */
-  public async protocolFee(
-    params?: ReadParams<typeof boostCoreAbi, 'protocolFee'>,
-  ) {
+  public async protocolFee(params?: ReadParams) {
     return await readBoostCoreProtocolFee(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -984,9 +968,7 @@ export class BoostCore extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async protocolFeeReceiver(
-    params?: ReadParams<typeof boostCoreAbi, 'protocolFeeReceiver'>,
-  ) {
+  public async protocolFeeReceiver(params?: ReadParams) {
     return await readBoostCoreProtocolFeeReceiver(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -1009,10 +991,7 @@ export class BoostCore extends Deployable<
    * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
-  public async setProcolFeeReceiver(
-    address: Address,
-    params?: WriteParams<typeof boostCoreAbi, 'setProtocolFeeReceiver'>,
-  ) {
+  public async setProcolFeeReceiver(address: Address, params?: WriteParams) {
     return await this.awaitResult(
       this.setProcolFeeReceiverRaw(address, {
         ...params,
@@ -1029,10 +1008,7 @@ export class BoostCore extends Deployable<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
-  public async setProcolFeeReceiverRaw(
-    address: Address,
-    params?: WriteParams<typeof boostCoreAbi, 'setProtocolFeeReceiver'>,
-  ) {
+  public async setProcolFeeReceiverRaw(address: Address, params?: WriteParams) {
     const { request, result } = await simulateBoostCoreSetProtocolFeeReceiver(
       this._config,
       {

--- a/packages/sdk/src/BoostRegistry.ts
+++ b/packages/sdk/src/BoostRegistry.ts
@@ -30,7 +30,6 @@ import {
   type HashAndSimulatedResult,
   type ReadParams,
   type RegistryType,
-  type SimulateParams,
   type WriteParams,
   assertValidAddressByChainId,
 } from './utils';
@@ -275,7 +274,7 @@ export class BoostRegistry extends Deployable<
     registryType: RegistryType,
     name: string,
     implementation: Address,
-    params?: SimulateParams,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateBoostRegistryRegister(
       this._config,
@@ -406,7 +405,7 @@ export class BoostRegistry extends Deployable<
     const { address: baseAddress } = assertValidAddressByChainId(
       this._config,
       target.bases,
-      params?.chain?.id || params?.chainId,
+      params?.chainId,
     );
     const { request, result } = await simulateBoostRegistryDeployClone(
       this._config,
@@ -414,7 +413,7 @@ export class BoostRegistry extends Deployable<
         ...assertValidAddressByChainId(
           this._config,
           this.addresses,
-          params?.chain?.id || params?.chainId,
+          params?.chainId,
         ),
         args: [target.registryType, baseAddress, displayName, payload.args[0]],
         ...this.optionallyAttachAccount(),

--- a/packages/sdk/src/BoostRegistry.ts
+++ b/packages/sdk/src/BoostRegistry.ts
@@ -30,6 +30,7 @@ import {
   type HashAndSimulatedResult,
   type ReadParams,
   type RegistryType,
+  type SimulateParams,
   type WriteParams,
   assertValidAddressByChainId,
 } from './utils';
@@ -253,7 +254,7 @@ export class BoostRegistry extends Deployable<
     registryType: RegistryType,
     name: string,
     implementation: Address,
-    params?: WriteParams<typeof boostRegistryAbi, 'register'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.registerRaw(registryType, name, implementation, params),
@@ -274,7 +275,7 @@ export class BoostRegistry extends Deployable<
     registryType: RegistryType,
     name: string,
     implementation: Address,
-    params?: WriteParams<typeof boostRegistryAbi, 'register'>,
+    params?: SimulateParams,
   ) {
     const { request, result } = await simulateBoostRegistryRegister(
       this._config,
@@ -282,7 +283,7 @@ export class BoostRegistry extends Deployable<
         ...assertValidAddressByChainId(
           this._config,
           this.addresses,
-          params?.chain?.id || params?.chainId,
+          params?.chainId,
         ),
         args: [registryType, name, implementation],
         ...this.optionallyAttachAccount(),
@@ -310,7 +311,7 @@ export class BoostRegistry extends Deployable<
   public initialize<Target extends DeployableTarget<any, any>>(
     displayName: string,
     target: Target,
-    params?: WriteParams<typeof boostRegistryAbi, 'deployClone'>,
+    params?: WriteParams,
   ): Promise<Target> {
     return this.clone(displayName, target, params);
   }
@@ -330,7 +331,7 @@ export class BoostRegistry extends Deployable<
   public async initializeRaw<Target extends DeployableTarget<unknown, Abi>>(
     displayName: string,
     target: Target,
-    params?: WriteParams<typeof boostRegistryAbi, 'deployClone'>,
+    params?: WriteParams,
   ): Promise<HashAndSimulatedResult<Address> & { target: Target }> {
     const { hash, result } = await this.deployCloneRaw(
       displayName,
@@ -355,7 +356,7 @@ export class BoostRegistry extends Deployable<
   public async clone<Target extends DeployableTarget<any, any>>(
     displayName: string,
     target: Target,
-    params?: WriteParams<typeof boostRegistryAbi, 'deployClone'>,
+    params?: WriteParams,
   ): Promise<Target> {
     const instance = await this.deployClone(displayName, target, params);
     return target.at(instance);
@@ -376,7 +377,7 @@ export class BoostRegistry extends Deployable<
   public async deployClone<Target extends DeployableTarget<any, any>>(
     displayName: string,
     target: Target,
-    params?: WriteParams<typeof boostRegistryAbi, 'deployClone'>,
+    params?: WriteParams,
   ): Promise<Address> {
     return await this.awaitResult(
       this.deployCloneRaw(displayName, target, params),
@@ -396,7 +397,7 @@ export class BoostRegistry extends Deployable<
   public async deployCloneRaw<Target extends DeployableTarget<any, any>>(
     displayName: string,
     target: Target,
-    params?: WriteParams<typeof boostRegistryAbi, 'deployClone'>,
+    params?: WriteParams,
   ): Promise<HashAndSimulatedResult<Address>> {
     const payload = target.buildParameters(undefined, {
       config: this._config,
@@ -435,10 +436,7 @@ export class BoostRegistry extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>} - The address of the implementation
    */
-  public async getBaseImplementation(
-    identifier: Hex,
-    params?: ReadParams<typeof boostRegistryAbi, 'getBaseImplementation'>,
-  ) {
+  public async getBaseImplementation(identifier: Hex, params?: ReadParams) {
     return await readBoostRegistryGetBaseImplementation(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -461,10 +459,7 @@ export class BoostRegistry extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {Promise<Clone>} - The on-chain representation of the clone
    */
-  public async getClone(
-    identifier: Hex,
-    params?: ReadParams<typeof boostRegistryAbi, 'getClone'>,
-  ): Promise<Clone> {
+  public async getClone(identifier: Hex, params?: ReadParams): Promise<Clone> {
     return await readBoostRegistryGetClone(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -487,10 +482,7 @@ export class BoostRegistry extends Deployable<
    * @param {?ReadParams} [params]
    * @returns {Promise<Hex[]>} - The list of deployed clones for the given deployer
    */
-  public async getClones(
-    deployer: Address,
-    params?: ReadParams<typeof boostRegistryAbi, 'getClones'>,
-  ) {
+  public async getClones(deployer: Address, params?: ReadParams) {
     return await readBoostRegistryGetClones(this._config, {
       ...assertValidAddressByChainId(
         this._config,
@@ -521,7 +513,7 @@ export class BoostRegistry extends Deployable<
     base: Address,
     deployer: Address,
     displayName: string,
-    params?: ReadParams<typeof boostRegistryAbi, 'getCloneIdentifier'>,
+    params?: ReadParams,
   ) {
     return await readBoostRegistryGetCloneIdentifier(this._config, {
       ...assertValidAddressByChainId(
@@ -549,7 +541,7 @@ export class BoostRegistry extends Deployable<
   public async getIdentifier(
     registryType: RegistryType,
     displayName: string,
-    params?: ReadParams<typeof boostRegistryAbi, 'getIdentifier'>,
+    params?: ReadParams,
   ) {
     return await readBoostRegistryGetCloneIdentifier(this._config, {
       ...assertValidAddressByChainId(

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -216,7 +216,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async allocate(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof managedBudgetAbi, 'allocate'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.allocateRaw(transfer, params));
   }
@@ -234,7 +234,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async allocateRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof managedBudgetAbi, 'allocate'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateManagedBudgetAllocate(
       this._config,
@@ -264,7 +264,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async clawback(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof managedBudgetAbi, 'clawback'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.clawbackRaw(transfer, params));
   }
@@ -283,7 +283,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async clawbackRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof managedBudgetAbi, 'clawback'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateManagedBudgetClawback(
       this._config,
@@ -327,7 +327,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
     data: Hex,
     boostId: bigint | number,
     incentiveId: bigint | number,
-    params?: WriteParams<typeof managedBudgetAbi, 'clawbackFromTarget'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.clawbackFromTargetRaw(target, data, boostId, incentiveId, params),
@@ -362,7 +362,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
     data: Hex,
     boostId: bigint | number,
     incentiveId: bigint | number,
-    params?: WriteParams<typeof managedBudgetAbi, 'clawbackFromTarget'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateManagedBudgetClawbackFromTarget(
       this._config,
@@ -393,7 +393,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async disburse(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof managedBudgetAbi, 'disburse'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.disburseRaw(transfer, params));
   }
@@ -410,7 +410,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async disburseRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof managedBudgetAbi, 'disburse'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateManagedBudgetDisburse(
       this._config,
@@ -437,7 +437,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async disburseBatch(
     transfers: Array<FungibleTransferPayload | ERC1155TransferPayload>,
-    params?: WriteParams<typeof managedBudgetAbi, 'disburseBatch'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.disburseBatchRaw(transfers, params));
   }
@@ -453,7 +453,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    */
   public async disburseBatchRaw(
     transfers: Array<FungibleTransferPayload | ERC1155TransferPayload>,
-    params?: WriteParams<typeof managedBudgetAbi, 'disburseBatch'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateManagedBudgetDisburseBatch(
       this._config,
@@ -476,7 +476,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public owner(params?: ReadParams<typeof managedBudgetAbi, 'owner'>) {
+  public owner(params?: ReadParams) {
     return readManagedBudgetOwner(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -498,7 +498,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
   public total(
     asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
-    params?: ReadParams<typeof managedBudgetAbi, 'total'>,
+    params?: ReadParams,
   ) {
     return readManagedBudgetTotal(this._config, {
       address: this.assertValidAddress(),
@@ -521,7 +521,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
   public available(
     asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
-    params?: ReadParams<typeof managedBudgetAbi, 'available'>,
+    params?: ReadParams,
   ) {
     return readManagedBudgetAvailable(this._config, {
       address: this.assertValidAddress(),
@@ -544,7 +544,7 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
   public distributed(
     asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
-    params?: ReadParams<typeof managedBudgetAbi, 'distributed'>,
+    params?: ReadParams,
   ) {
     return readManagedBudgetDistributed(this._config, {
       address: this.assertValidAddress(),

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -148,7 +148,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public owner(params?: ReadParams<typeof vestingBudgetAbi, 'owner'>) {
+  public owner(params?: ReadParams) {
     return readVestingBudgetOwner(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -164,7 +164,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public start(params?: ReadParams<typeof vestingBudgetAbi, 'start'>) {
+  public start(params?: ReadParams) {
     return readVestingBudgetStart(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -180,7 +180,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public duration(params?: ReadParams<typeof vestingBudgetAbi, 'duration'>) {
+  public duration(params?: ReadParams) {
     return readVestingBudgetDuration(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -196,7 +196,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public cliff(params?: ReadParams<typeof vestingBudgetAbi, 'cliff'>) {
+  public cliff(params?: ReadParams) {
     return readVestingBudgetCliff(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -218,7 +218,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async allocate(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'allocate'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.allocateRaw(transfer, params));
   }
@@ -236,7 +236,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async allocateRaw(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'allocate'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateVestingBudgetAllocate(
       this._config,
@@ -266,7 +266,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async clawback(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'clawback'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.clawbackRaw(transfer, params));
   }
@@ -285,7 +285,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async clawbackRaw(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'clawback'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateVestingBudgetClawback(
       this._config,
@@ -313,7 +313,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async disburse(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'disburse'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.disburseRaw(transfer, params));
   }
@@ -330,7 +330,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async disburseRaw(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'disburse'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateVestingBudgetDisburse(
       this._config,
@@ -357,7 +357,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async disburseBatch(
     transfers: FungibleTransferPayload[],
-    params?: WriteParams<typeof vestingBudgetAbi, 'disburseBatch'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.disburseBatchRaw(transfers, params));
   }
@@ -373,7 +373,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    */
   public async disburseBatchRaw(
     transfers: FungibleTransferPayload[],
-    params?: WriteParams<typeof vestingBudgetAbi, 'disburseBatch'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateVestingBudgetDisburseBatch(
       this._config,
@@ -396,7 +396,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public end(params?: ReadParams<typeof vestingBudgetAbi, 'end'>) {
+  public end(params?: ReadParams) {
     return readVestingBudgetEnd(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -414,10 +414,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public total(
-    asset: Address = zeroAddress,
-    params?: ReadParams<typeof vestingBudgetAbi, 'total'>,
-  ) {
+  public total(asset: Address = zeroAddress, params?: ReadParams) {
     return readVestingBudgetTotal(this._config, {
       address: this.assertValidAddress(),
       args: [asset],
@@ -435,10 +432,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The amount of assets currently available for distribution
    */
-  public available(
-    asset: Address = zeroAddress,
-    params?: ReadParams<typeof vestingBudgetAbi, 'available'>,
-  ) {
+  public available(asset: Address = zeroAddress, params?: ReadParams) {
     return readVestingBudgetAvailable(this._config, {
       address: this.assertValidAddress(),
       args: [asset],
@@ -455,10 +449,7 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The amount of assets distributed
    */
-  public distributed(
-    asset: Address = zeroAddress,
-    params?: ReadParams<typeof vestingBudgetAbi, 'distributed'>,
-  ) {
+  public distributed(asset: Address = zeroAddress, params?: ReadParams) {
     return readVestingBudgetDistributed(this._config, {
       address: this.assertValidAddress(),
       args: [asset],

--- a/packages/sdk/src/Deployable/DeployableTarget.ts
+++ b/packages/sdk/src/Deployable/DeployableTarget.ts
@@ -177,10 +177,7 @@ export class DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the contract supports the interface
    */
-  public async supportsInterface(
-    interfaceId: Hex,
-    params?: ReadParams<typeof aCloneableAbi, 'supportsInterface'>,
-  ) {
+  public async supportsInterface(interfaceId: Hex, params?: ReadParams) {
     return await readACloneableSupportsInterface(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
@@ -199,9 +196,7 @@ export class DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
-  public async getComponentInterface(
-    params?: ReadParams<typeof aCloneableAbi, 'getComponentInterface'>,
-  ) {
+  public async getComponentInterface(params?: ReadParams) {
     return await readACloneableGetComponentInterface(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -78,7 +78,7 @@ export class DeployableTargetWithRBAC<
   public async setAuthorized(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof rbacAbi, 'setAuthorized'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.setAuthorizedRaw(addresses, allowed, params),
@@ -99,7 +99,7 @@ export class DeployableTargetWithRBAC<
   public async setAuthorizedRaw(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof rbacAbi, 'setAuthorized'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateRbacSetAuthorized(this._config, {
       address: this.assertValidAddress(),
@@ -123,14 +123,10 @@ export class DeployableTargetWithRBAC<
    * @async
    * @param {Address} address
    * @param {Roles} role
-   * @param {?WriteParams<typeof rbacAbi, 'grantRoles'>} [params]
+   * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
-  public async grantRoles(
-    address: Address,
-    role: Roles,
-    params?: WriteParams<typeof rbacAbi, 'grantRoles'>,
-  ) {
+  public async grantRoles(address: Address, role: Roles, params?: WriteParams) {
     return await this.awaitResult(this.grantRolesRaw(address, role, params));
   }
 
@@ -151,7 +147,7 @@ export class DeployableTargetWithRBAC<
   public async grantRolesRaw(
     address: Address,
     role: Roles,
-    params?: WriteParams<typeof rbacAbi, 'grantRoles'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateRbacGrantRoles(this._config, {
       address: this.assertValidAddress(),
@@ -185,7 +181,7 @@ export class DeployableTargetWithRBAC<
   public async revokeRoles(
     address: Address,
     role: Roles,
-    params?: WriteParams<typeof rbacAbi, 'revokeRoles'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.revokeRolesRaw(address, role, params));
   }
@@ -207,7 +203,7 @@ export class DeployableTargetWithRBAC<
   public async revokeRolesRaw(
     address: Address,
     role: Roles,
-    params?: WriteParams<typeof rbacAbi, 'revokeRoles'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateRbacRevokeRoles(this._config, {
       address: this.assertValidAddress(),
@@ -241,7 +237,7 @@ export class DeployableTargetWithRBAC<
   public async grantManyRoles(
     addresses: Address[],
     roles: Roles[],
-    params?: WriteParams<typeof rbacAbi, 'grantManyRoles'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.grantManyRolesRaw(addresses, roles, params),
@@ -265,7 +261,7 @@ export class DeployableTargetWithRBAC<
   public async grantManyRolesRaw(
     addresses: Address[],
     roles: Roles[],
-    params?: WriteParams<typeof rbacAbi, 'grantManyRoles'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateRbacGrantManyRoles(this._config, {
       address: this.assertValidAddress(),
@@ -299,7 +295,7 @@ export class DeployableTargetWithRBAC<
   public async revokeManyRoles(
     addresses: Address[],
     roles: Roles[],
-    params?: WriteParams<typeof rbacAbi, 'revokeManyRoles'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.revokeManyRolesRaw(addresses, roles, params),
@@ -323,7 +319,7 @@ export class DeployableTargetWithRBAC<
   public async revokeManyRolesRaw(
     addresses: Address[],
     roles: Roles[],
-    params?: WriteParams<typeof rbacAbi, 'revokeManyRoles'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateRbacRevokeManyRoles(
       this._config,
@@ -354,10 +350,7 @@ export class DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<Array<Roles>>}
    */
-  public async rolesOf(
-    account: Address,
-    params?: ReadParams<typeof rbacAbi, 'rolesOf'>,
-  ) {
+  public async rolesOf(account: Address, params?: ReadParams) {
     const roles = await readRbacRolesOf(this._config, {
       address: this.assertValidAddress(),
       args: [account],
@@ -383,11 +376,7 @@ export class DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public hasAnyRole(
-    account: Address,
-    roles: Roles,
-    params?: ReadParams<typeof rbacAbi, 'hasAnyRole'>,
-  ) {
+  public hasAnyRole(account: Address, roles: Roles, params?: ReadParams) {
     return readRbacHasAnyRole(this._config, {
       address: this.assertValidAddress(),
       args: [account, roles],
@@ -410,11 +399,7 @@ export class DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public hasAllRoles(
-    account: Address,
-    roles: Roles,
-    params?: ReadParams<typeof rbacAbi, 'hasAllRoles'>,
-  ) {
+  public hasAllRoles(account: Address, roles: Roles, params?: ReadParams) {
     return readRbacHasAllRoles(this._config, {
       address: this.assertValidAddress(),
       args: [account, roles],
@@ -432,10 +417,7 @@ export class DeployableTargetWithRBAC<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the account is authorized
    */
-  public isAuthorized(
-    account: Address,
-    params?: ReadParams<typeof rbacAbi, 'isAuthorized'>,
-  ) {
+  public isAuthorized(account: Address, params?: ReadParams) {
     return readRbacIsAuthorized(this._config, {
       address: this.assertValidAddress(),
       args: [account],

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -117,9 +117,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async owner(
-    params?: ReadParams<typeof allowListIncentiveAbi, 'owner'>,
-  ) {
+  public async owner(params?: ReadParams) {
     return await readAllowListIncentiveOwner(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -136,9 +134,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async claims(
-    params?: ReadParams<typeof allowListIncentiveAbi, 'claims'>,
-  ) {
+  public async claims(params?: ReadParams) {
     return await readAllowListIncentiveClaims(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -155,9 +151,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async reward(
-    params?: ReadParams<typeof allowListIncentiveAbi, 'reward'>,
-  ) {
+  public async reward(params?: ReadParams) {
     return await readAllowListIncentiveReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -175,10 +169,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async claimed(
-    address: Address,
-    params?: ReadParams<typeof allowListIncentiveAbi, 'claimed'>,
-  ) {
+  public async claimed(address: Address, params?: ReadParams) {
     return await readAllowListIncentiveClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -195,9 +186,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<SimpleAllowList>}
    */
-  public async allowList(
-    params?: ReadParams<typeof allowListIncentiveAbi, 'allowList'>,
-  ): Promise<SimpleAllowList> {
+  public async allowList(params?: ReadParams): Promise<SimpleAllowList> {
     const address = await readAllowListIncentiveAllowList(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -217,9 +206,7 @@ export class AllowListIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async limit(
-    params?: ReadParams<typeof allowListIncentiveAbi, 'limit'>,
-  ) {
+  public async limit(params?: ReadParams) {
     return await readAllowListIncentiveLimit(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -238,7 +225,7 @@ export class AllowListIncentive extends DeployableTarget<
    */
   protected async claim(
     payload: Pick<ClaimPayload, 'target'>,
-    params?: WriteParams<typeof allowListIncentiveAbi, 'claim'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.claimRaw(payload, params));
   }
@@ -254,7 +241,7 @@ export class AllowListIncentive extends DeployableTarget<
    */
   protected async claimRaw(
     payload: Pick<ClaimPayload, 'target'>,
-    params?: WriteParams<typeof allowListIncentiveAbi, 'claim'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateAllowListIncentiveClaim(
       this._config,
@@ -281,7 +268,7 @@ export class AllowListIncentive extends DeployableTarget<
    */
   public async isClaimable(
     payload: Pick<ClaimPayload, 'target'>,
-    params?: ReadParams<typeof allowListIncentiveAbi, 'isClaimable'>,
+    params?: ReadParams,
   ) {
     return await readAllowListIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -175,7 +175,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async owner(params?: ReadParams<typeof cgdaIncentiveAbi, 'owner'>) {
+  public async owner(params?: ReadParams) {
     return await readCgdaIncentiveOwner(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -192,7 +192,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async claims(params?: ReadParams<typeof cgdaIncentiveAbi, 'claims'>) {
+  public async claims(params?: ReadParams) {
     return await readCgdaIncentiveClaims(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -209,7 +209,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async reward(params?: ReadParams<typeof cgdaIncentiveAbi, 'reward'>) {
+  public async reward(params?: ReadParams) {
     return await readCgdaIncentiveReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -227,10 +227,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async claimed(
-    address: Address,
-    params?: ReadParams<typeof cgdaIncentiveAbi, 'claimed'>,
-  ) {
+  public async claimed(address: Address, params?: ReadParams) {
     return await readCgdaIncentiveClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -247,7 +244,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async asset(params?: ReadParams<typeof cgdaIncentiveAbi, 'asset'>) {
+  public async asset(params?: ReadParams) {
     return await readCgdaIncentiveAsset(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -263,9 +260,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<CGDAParameters>}
    */
-  public async cgdaParams(
-    params?: ReadParams<typeof cgdaIncentiveAbi, 'cgdaParams'>,
-  ): Promise<CGDAParameters> {
+  public async cgdaParams(params?: ReadParams): Promise<CGDAParameters> {
     const [rewardDecay, rewardBoost, lastClaimTime, currentReward] =
       await readCgdaIncentiveCgdaParams(this._config, {
         address: this.assertValidAddress(),
@@ -288,9 +283,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async totalBudget(
-    params?: ReadParams<typeof cgdaIncentiveAbi, 'totalBudget'>,
-  ) {
+  public async totalBudget(params?: ReadParams) {
     return await readCgdaIncentiveTotalBudget(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -307,10 +300,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
-  protected async claim(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof cgdaIncentiveAbi, 'claim'>,
-  ) {
+  protected async claim(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.claimRaw(payload, params));
   }
 
@@ -323,10 +313,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
-  protected async claimRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof cgdaIncentiveAbi, 'claim'>,
-  ) {
+  protected async claimRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateCgdaIncentiveClaim(this._config, {
       address: this.assertValidAddress(),
       args: [prepareClaimPayload(payload)],
@@ -347,10 +334,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async clawback(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof cgdaIncentiveAbi, 'clawback'>,
-  ) {
+  public async clawback(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.clawbackRaw(payload, params));
   }
 
@@ -363,10 +347,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async clawbackRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof cgdaIncentiveAbi, 'clawback'>,
-  ) {
+  public async clawbackRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateCgdaIncentiveClawback(
       this._config,
       {
@@ -390,10 +371,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} - True if the incentive is claimable based on the data payload
    */
-  public async isClaimable(
-    payload: ClaimPayload,
-    params?: ReadParams<typeof cgdaIncentiveAbi, 'isClaimable'>,
-  ) {
+  public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readCgdaIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
       args: [prepareClaimPayload(payload)],
@@ -412,9 +390,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
-  public async currentReward(
-    params?: ReadParams<typeof cgdaIncentiveAbi, 'currentReward'>,
-  ) {
+  public async currentReward(params?: ReadParams) {
     return await readCgdaIncentiveCurrentReward(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -149,9 +149,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async claims(
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'claims'>,
-  ) {
+  public async claims(params?: ReadParams) {
     return await readErc1155IncentiveClaims(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -168,9 +166,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async reward(
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'reward'>,
-  ) {
+  public async reward(params?: ReadParams) {
     return await readErc1155IncentiveReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -188,10 +184,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async claimed(
-    address: Address,
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'claimed'>,
-  ) {
+  public async claimed(address: Address, params?: ReadParams) {
     return await readErc1155IncentiveClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -208,7 +201,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async asset(params?: ReadParams<typeof erc1155IncentiveAbi, 'asset'>) {
+  public async asset(params?: ReadParams) {
     return await readErc1155IncentiveAsset(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -224,9 +217,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<StrategyType>}
    */
-  public strategy(
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'strategy'>,
-  ): Promise<StrategyType> {
+  public strategy(params?: ReadParams): Promise<StrategyType> {
     return readErc1155IncentiveStrategy(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -242,7 +233,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {unknown}
    */
-  public async limit(params?: ReadParams<typeof erc1155IncentiveAbi, 'limit'>) {
+  public async limit(params?: ReadParams) {
     return await readErc1155IncentiveLimit(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -258,9 +249,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async tokenId(
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'tokenId'>,
-  ) {
+  public async tokenId(params?: ReadParams) {
     return await readErc1155IncentiveTokenId(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -276,9 +265,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
-  public async extraData(
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'extraData'>,
-  ) {
+  public async extraData(params?: ReadParams) {
     return await readErc1155IncentiveExtraData(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -295,10 +282,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>}
    */
-  protected async claim(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc1155IncentiveAbi, 'claim'>,
-  ) {
+  protected async claim(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.claimRaw(payload, params));
   }
 
@@ -311,10 +295,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>}
    */
-  protected async claimRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc1155IncentiveAbi, 'claim'>,
-  ) {
+  protected async claimRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateErc1155IncentiveClaim(
       this._config,
       {
@@ -338,10 +319,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async clawback(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc1155IncentiveAbi, 'clawback'>,
-  ) {
+  public async clawback(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.clawbackRaw(payload, params));
   }
 
@@ -354,10 +332,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>}
    */
-  public async clawbackRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc1155IncentiveAbi, 'clawback'>,
-  ) {
+  public async clawbackRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateErc1155IncentiveClawback(
       this._config,
       {
@@ -381,10 +356,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async isClaimable(
-    payload: ClaimPayload,
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'isClaimable'>,
-  ) {
+  public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readErc1155IncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
       args: [prepareClaimPayload(payload)],
@@ -402,10 +374,7 @@ export class ERC1155Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
-  public async preflight(
-    data: ERC1155IncentivePayload,
-    params?: ReadParams<typeof erc1155IncentiveAbi, 'preflight'>,
-  ) {
+  public async preflight(data: ERC1155IncentivePayload, params?: ReadParams) {
     return await readErc1155IncentivePreflight(this._config, {
       address: this.assertValidAddress(),
       args: [prepareERC1155IncentivePayload(data)],

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -144,7 +144,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async owner(params?: ReadParams<typeof erc20IncentiveAbi, 'owner'>) {
+  public async owner(params?: ReadParams) {
     return await readErc20IncentiveOwner(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -161,9 +161,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
-  public async currentReward(
-    params?: ReadParams<typeof erc20IncentiveAbi, 'currentReward'>,
-  ) {
+  public async currentReward(params?: ReadParams) {
     return await readErc20IncentiveCurrentReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -180,7 +178,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async claims(params?: ReadParams<typeof erc20IncentiveAbi, 'claims'>) {
+  public async claims(params?: ReadParams) {
     return await readErc20IncentiveClaims(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -198,10 +196,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async claimed(
-    address: Address,
-    params?: ReadParams<typeof erc20IncentiveAbi, 'claimed'>,
-  ) {
+  public async claimed(address: Address, params?: ReadParams) {
     return await readErc20IncentiveClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -218,7 +213,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async asset(params?: ReadParams<typeof erc20IncentiveAbi, 'asset'>) {
+  public async asset(params?: ReadParams) {
     return await readErc20IncentiveAsset(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -234,9 +229,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<StrategyType>}
    */
-  public strategy(
-    params?: ReadParams<typeof erc20IncentiveAbi, 'strategy'>,
-  ): Promise<StrategyType> {
+  public strategy(params?: ReadParams): Promise<StrategyType> {
     return readErc20IncentiveStrategy(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -252,7 +245,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async reward(params?: ReadParams<typeof erc20IncentiveAbi, 'reward'>) {
+  public async reward(params?: ReadParams) {
     return await readErc20IncentiveReward(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -268,7 +261,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async limit(params?: ReadParams<typeof erc20IncentiveAbi, 'limit'>) {
+  public async limit(params?: ReadParams) {
     return await readErc20IncentiveLimit(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -285,10 +278,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async entries(
-    i: bigint,
-    params?: ReadParams<typeof erc20IncentiveAbi, 'entries'>,
-  ) {
+  public async entries(i: bigint, params?: ReadParams) {
     return await readErc20IncentiveEntries(this._config, {
       address: this.assertValidAddress(),
       args: [i],
@@ -306,10 +296,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
-  protected async claim(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20IncentiveAbi, 'claim'>,
-  ) {
+  protected async claim(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.claimRaw(payload, params));
   }
 
@@ -322,10 +309,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
    */
-  protected async claimRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20IncentiveAbi, 'claim'>,
-  ) {
+  protected async claimRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateErc20IncentiveClaim(
       this._config,
       {
@@ -349,10 +333,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async clawback(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20IncentiveAbi, 'clawback'>,
-  ) {
+  public async clawback(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.clawbackRaw(payload, params));
   }
 
@@ -365,10 +346,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
    */
-  public async clawbackRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20IncentiveAbi, 'clawback'>,
-  ) {
+  public async clawbackRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateErc20IncentiveClawback(
       this._config,
       {
@@ -392,10 +370,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
    */
-  public async isClaimable(
-    payload: ClaimPayload,
-    params?: ReadParams<typeof erc20IncentiveAbi, 'isClaimable'>,
-  ) {
+  public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readErc20IncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
       args: [prepareClaimPayload(payload)],
@@ -412,9 +387,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
-  public async drawRaffle(
-    params?: WriteParams<typeof erc20IncentiveAbi, 'drawRaffle'>,
-  ) {
+  public async drawRaffle(params?: WriteParams) {
     return await this.awaitResult(this.drawRaffleRaw(params));
   }
 
@@ -426,9 +399,7 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
-  public async drawRaffleRaw(
-    params?: WriteParams<typeof erc20IncentiveAbi, 'drawRaffle'>,
-  ) {
+  public async drawRaffleRaw(params?: WriteParams) {
     const { request, result } = await simulateErc20IncentiveDrawRaffle(
       this._config,
       {

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
@@ -94,11 +94,7 @@ export interface IncentiveCriteria {
   targetContract: Address;
 }
 
-export interface ReadIncentiveCriteriaParams
-  extends ReadParams<
-    typeof erc20VariableCriteriaIncentiveAbi,
-    'getIncentiveCriteria'
-  > {}
+export interface ReadIncentiveCriteriaParams extends ReadParams {}
 
 export interface GetIncentiveScalarParams {
   chainId: number;
@@ -144,10 +140,7 @@ export class ERC20VariableCriteriaIncentive extends ERC20VariableIncentive<
    * @throws {IncentiveCriteriaNotFoundError}
    */
   public async getIncentiveCriteria(
-    params?: ReadParams<
-      typeof erc20VariableCriteriaIncentiveAbi,
-      'getIncentiveCriteria'
-    >,
+    params?: ReadParams,
   ): Promise<IncentiveCriteria> {
     try {
       const criteria =
@@ -172,12 +165,7 @@ export class ERC20VariableCriteriaIncentive extends ERC20VariableIncentive<
    * @returns {Promise<IncentiveCriteria>} Incentive criteria structure
    * @throws {IncentiveCriteriaNotFoundError}
    */
-  public async getMaxReward(
-    params?: ReadParams<
-      typeof erc20VariableCriteriaIncentiveAbi,
-      'getIncentiveCriteria'
-    >,
-  ): Promise<bigint> {
+  public async getMaxReward(params?: ReadParams): Promise<bigint> {
     const maxReward = await readErc20VariableCriteriaIncentiveGetMaxReward(
       this._config,
       {
@@ -199,10 +187,7 @@ export class ERC20VariableCriteriaIncentive extends ERC20VariableIncentive<
    */
   public async getIncentiveScalar(
     { chainId, hash, knownSignatures }: GetIncentiveScalarParams,
-    params?: ReadParams<
-      typeof erc20VariableCriteriaIncentiveAbi,
-      'getIncentiveCriteria'
-    >,
+    params?: ReadParams,
   ): Promise<bigint> {
     const criteria = await this.getIncentiveCriteria(params);
     if (criteria.criteriaType === SignatureType.EVENT) {

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -130,9 +130,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async owner(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'owner'>,
-  ) {
+  public async owner(params?: ReadParams) {
     return await readErc20VariableIncentiveOwner(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -149,9 +147,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async totalClaimed(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'totalClaimed'>,
-  ) {
+  public async totalClaimed(params?: ReadParams) {
     return await readErc20VariableIncentiveTotalClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -168,9 +164,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
-  public async currentReward(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'currentReward'>,
-  ) {
+  public async currentReward(params?: ReadParams) {
     return await readErc20VariableIncentiveCurrentReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -187,9 +181,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async claims(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'claims'>,
-  ) {
+  public async claims(params?: ReadParams) {
     return await readErc20VariableIncentiveClaims(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -207,10 +199,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async claimed(
-    address: Address,
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'claimed'>,
-  ) {
+  public async claimed(address: Address, params?: ReadParams) {
     return await readErc20VariableIncentiveClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -227,9 +216,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async asset(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'asset'>,
-  ) {
+  public async asset(params?: ReadParams) {
     return await readErc20VariableIncentiveAsset(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -245,9 +232,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async reward(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'reward'>,
-  ) {
+  public async reward(params?: ReadParams) {
     return await readErc20VariableIncentiveReward(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -263,9 +248,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async limit(
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'limit'>,
-  ) {
+  public async limit(params?: ReadParams) {
     return await readErc20VariableIncentiveLimit(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -282,10 +265,7 @@ export class ERC20VariableIncentive<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} - Returns true if successfully claimed
    */
-  protected async claim(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20VariableIncentiveAbi, 'claim'>,
-  ) {
+  protected async claim(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.claimRaw(payload, params));
   }
 
@@ -298,10 +278,7 @@ export class ERC20VariableIncentive<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
    */
-  protected async claimRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20VariableIncentiveAbi, 'claim'>,
-  ) {
+  protected async claimRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateErc20VariableIncentiveClaim(
       this._config,
       {
@@ -325,10 +302,7 @@ export class ERC20VariableIncentive<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async clawback(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20VariableIncentiveAbi, 'clawback'>,
-  ) {
+  public async clawback(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.clawbackRaw(payload, params));
   }
 
@@ -341,10 +315,7 @@ export class ERC20VariableIncentive<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
    */
-  public async clawbackRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof erc20VariableIncentiveAbi, 'clawback'>,
-  ) {
+  public async clawbackRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulateErc20VariableIncentiveClawback(
       this._config,
       {
@@ -371,10 +342,7 @@ export class ERC20VariableIncentive<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
    */
-  public async isClaimable(
-    payload: ClaimPayload,
-    params?: ReadParams<typeof erc20VariableIncentiveAbi, 'isClaimable'>,
-  ) {
+  public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readErc20VariableIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
       args: [prepareClaimPayload(payload)],

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -130,9 +130,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async claims(
-    params?: ReadParams<typeof pointsIncentiveAbi, 'claims'>,
-  ) {
+  public async claims(params?: ReadParams) {
     return await readPointsIncentiveClaims(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -149,9 +147,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} - The current reward
    */
-  public async currentReward(
-    params?: ReadParams<typeof pointsIncentiveAbi, 'currentReward'>,
-  ) {
+  public async currentReward(params?: ReadParams) {
     return await readPointsIncentiveCurrentReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -168,9 +164,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>} The reward amount issued for each claim
    */
-  public async reward(
-    params?: ReadParams<typeof pointsIncentiveAbi, 'reward'>,
-  ) {
+  public async reward(params?: ReadParams) {
     return await readPointsIncentiveReward(this._config, {
       address: this.assertValidAddress(),
       args: [],
@@ -188,10 +182,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async claimed(
-    address: Address,
-    params?: ReadParams<typeof pointsIncentiveAbi, 'claimed'>,
-  ) {
+  public async claimed(address: Address, params?: ReadParams) {
     return await readPointsIncentiveClaimed(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -208,7 +199,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Address>}
    */
-  public async venue(params?: ReadParams<typeof pointsIncentiveAbi, 'venue'>) {
+  public async venue(params?: ReadParams) {
     return await readPointsIncentiveVenue(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -224,7 +215,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<bigint>}
    */
-  public async limit(params?: ReadParams<typeof pointsIncentiveAbi, 'limit'>) {
+  public async limit(params?: ReadParams) {
     return await readPointsIncentiveLimit(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -240,9 +231,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<Hex>}
    */
-  public async selector(
-    params?: ReadParams<typeof pointsIncentiveAbi, 'selector'>,
-  ) {
+  public async selector(params?: ReadParams) {
     return await readPointsIncentiveSelector(this._config, {
       address: this.assertValidAddress(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -259,10 +248,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<boolean>} -  True if the incentive was successfully claimed
    */
-  protected async claim(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof pointsIncentiveAbi, 'claim'>,
-  ) {
+  protected async claim(payload: ClaimPayload, params?: WriteParams) {
     return await this.awaitResult(this.claimRaw(payload, params));
   }
 
@@ -275,10 +261,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the incentive was successfully claimed
    */
-  protected async claimRaw(
-    payload: ClaimPayload,
-    params?: WriteParams<typeof pointsIncentiveAbi, 'claim'>,
-  ) {
+  protected async claimRaw(payload: ClaimPayload, params?: WriteParams) {
     const { request, result } = await simulatePointsIncentiveClaim(
       this._config,
       {
@@ -304,10 +287,7 @@ export class PointsIncentive extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>} -  True if the incentive is claimable based on the data payload
    */
-  public async isClaimable(
-    payload: ClaimPayload,
-    params?: ReadParams<typeof pointsIncentiveAbi, 'isClaimable'>,
-  ) {
+  public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readPointsIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
       args: [prepareClaimPayload(payload)],

--- a/packages/sdk/src/Validators/LimitedSignerValidator.ts
+++ b/packages/sdk/src/Validators/LimitedSignerValidator.ts
@@ -339,10 +339,7 @@ export class LimitedSignerValidator extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async signers(
-    address: Address,
-    params?: ReadParams<typeof limitedSignerValidatorAbi, 'signers'>,
-  ) {
+  public async signers(address: Address, params?: ReadParams) {
     return await readLimitedSignerValidatorSigners(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -362,7 +359,7 @@ export class LimitedSignerValidator extends DeployableTarget<
    */
   public async hashSignerData(
     payload: LimitedSignerValidatorSignaturePayload,
-    params?: ReadParams<typeof limitedSignerValidatorAbi, 'hashSignerData'>,
+    params?: ReadParams,
   ) {
     return await readLimitedSignerValidatorHashSignerData(this._config, {
       address: this.assertValidAddress(),
@@ -388,7 +385,7 @@ export class LimitedSignerValidator extends DeployableTarget<
    */
   protected async validate(
     payload: LimitedSignerValidatorValidatePayload,
-    params?: WriteParams<typeof limitedSignerValidatorAbi, 'validate'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.validateRaw(payload, params));
   }
@@ -404,7 +401,7 @@ export class LimitedSignerValidator extends DeployableTarget<
    */
   protected async validateRaw(
     payload: LimitedSignerValidatorValidatePayload,
-    params?: ReadParams<typeof limitedSignerValidatorAbi, 'validate'>,
+    params?: ReadParams,
   ) {
     const { request, result } = await simulateLimitedSignerValidatorValidate(
       this._config,
@@ -441,7 +438,7 @@ export class LimitedSignerValidator extends DeployableTarget<
   public async setAuthorized(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof limitedSignerValidatorAbi, 'setAuthorized'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.setAuthorizedRaw(addresses, allowed, params),
@@ -461,7 +458,7 @@ export class LimitedSignerValidator extends DeployableTarget<
   public async setAuthorizedRaw(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof limitedSignerValidatorAbi, 'setAuthorized'>,
+    params?: WriteParams,
   ) {
     const { request, result } =
       await simulateLimitedSignerValidatorSetAuthorized(this._config, {
@@ -487,13 +484,7 @@ export class LimitedSignerValidator extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
-  public async setValidatorCallerRaw(
-    address: Address,
-    params?: WriteParams<
-      typeof limitedSignerValidatorAbi,
-      'setValidatorCaller'
-    >,
-  ) {
+  public async setValidatorCallerRaw(address: Address, params?: WriteParams) {
     const { request, result } =
       await simulateLimitedSignerValidatorSetValidatorCaller(this._config, {
         address: this.assertValidAddress(),
@@ -518,13 +509,7 @@ export class LimitedSignerValidator extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
-  public async setValidatorCaller(
-    address: Address,
-    params?: WriteParams<
-      typeof limitedSignerValidatorAbi,
-      'setValidatorCaller'
-    >,
-  ) {
+  public async setValidatorCaller(address: Address, params?: WriteParams) {
     return await this.awaitResult(this.setValidatorCallerRaw(address, params));
   }
 

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -331,10 +331,7 @@ export class SignerValidator extends DeployableTarget<
    * @param {?ReadParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async signers(
-    address: Address,
-    params?: ReadParams<typeof signerValidatorAbi, 'signers'>,
-  ) {
+  public async signers(address: Address, params?: ReadParams) {
     return await readSignerValidatorSigners(this._config, {
       address: this.assertValidAddress(),
       args: [address],
@@ -354,7 +351,7 @@ export class SignerValidator extends DeployableTarget<
    */
   public async hashSignerData(
     payload: SignerValidatorSignaturePayload,
-    params?: ReadParams<typeof signerValidatorAbi, 'hashSignerData'>,
+    params?: ReadParams,
   ) {
     return await readSignerValidatorHashSignerData(this._config, {
       address: this.assertValidAddress(),
@@ -380,7 +377,7 @@ export class SignerValidator extends DeployableTarget<
    */
   protected async validate(
     payload: SignerValidatorValidatePayload,
-    params?: WriteParams<typeof signerValidatorAbi, 'validate'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.validateRaw(payload, params));
   }
@@ -396,7 +393,7 @@ export class SignerValidator extends DeployableTarget<
    */
   protected async validateRaw(
     payload: SignerValidatorValidatePayload,
-    params?: ReadParams<typeof signerValidatorAbi, 'validate'>,
+    params?: ReadParams,
   ) {
     const { request, result } = await simulateSignerValidatorValidate(
       this._config,
@@ -430,7 +427,7 @@ export class SignerValidator extends DeployableTarget<
   public async setAuthorized(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof signerValidatorAbi, 'setAuthorized'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       this.setAuthorizedRaw(addresses, allowed, params),
@@ -450,7 +447,7 @@ export class SignerValidator extends DeployableTarget<
   public async setAuthorizedRaw(
     addresses: Address[],
     allowed: boolean[],
-    params?: WriteParams<typeof signerValidatorAbi, 'setAuthorized'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateSignerValidatorSetAuthorized(
       this._config,
@@ -475,10 +472,7 @@ export class SignerValidator extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
    */
-  public async setValidatorCallerRaw(
-    address: Address,
-    params?: WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>,
-  ) {
+  public async setValidatorCallerRaw(address: Address, params?: WriteParams) {
     const { request, result } = await simulateSignerValidatorSetValidatorCaller(
       this._config,
       {
@@ -505,10 +499,7 @@ export class SignerValidator extends DeployableTarget<
    * @param {?WriteParams} [params]
    * @returns {Promise<void>}
    */
-  public async setValidatorCaller(
-    address: Address,
-    params?: WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>,
-  ) {
+  public async setValidatorCaller(address: Address, params?: WriteParams) {
     return await this.awaitResult(this.setValidatorCallerRaw(address, params));
   }
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,8 +1,8 @@
 import {
   type Config,
   type ReadContractParameters,
+  type SimulateContractParameters,
   type WatchContractEventParameters,
-  type WriteContractParameters,
   getAccount,
   getClient,
   waitForTransactionReceipt,
@@ -23,7 +23,6 @@ import type {
 import { isHex, keccak256, slice, toHex } from 'viem';
 import {
   InvalidProtocolChainIdError,
-  NoConnectedChainIdError,
   NoContractAddressUponReceiptError,
 } from './errors';
 
@@ -70,14 +69,8 @@ export enum CheatCodes {
  * @template {Abi} abi
  * @template {ContractFunctionName<abi>} functionName
  */
-export type WriteParams<
-  abi extends Abi = Abi,
-  functionName extends ContractFunctionName<abi> = ContractFunctionName<abi>,
-> = Partial<
-  Omit<
-    WriteContractParameters<abi, functionName>,
-    'address' | 'args' | 'functionName' | 'abi'
-  >
+export type WriteParams = Partial<
+  Omit<SimulateContractParameters, 'address' | 'args' | 'functionName' | 'abi'>
 >;
 
 /**
@@ -89,14 +82,8 @@ export type WriteParams<
  * @template {Abi} abi
  * @template {ContractFunctionName<abi>} functionName
  */
-export type ReadParams<
-  abi extends Abi,
-  functionName extends ContractFunctionName<abi>,
-> = Partial<
-  Omit<
-    ReadContractParameters<abi, functionName>,
-    'address' | 'args' | 'functionName' | 'abi'
-  >
+export type ReadParams = Partial<
+  Omit<ReadContractParameters, 'address' | 'args' | 'functionName' | 'abi'>
 >;
 
 /**

--- a/test/src/MockERC1155.ts
+++ b/test/src/MockERC1155.ts
@@ -17,7 +17,7 @@ export class MockERC1155 extends Deployable<unknown, typeof mockErc1155Abi> {
     address: Address,
     id: bigint,
     amount: bigint,
-    params: WriteParams<typeof mockErc1155Abi, 'mint'> = {},
+    params: WriteParams = {},
   ) {
     return await this.awaitResult(this.mintRaw(address, id, amount, params));
   }
@@ -26,7 +26,7 @@ export class MockERC1155 extends Deployable<unknown, typeof mockErc1155Abi> {
     address: Address,
     id: bigint,
     amount: bigint,
-    params: WriteParams<typeof mockErc1155Abi, 'mint'> = {},
+    params: WriteParams = {},
   ) {
     const { request, result } = await simulateMockErc1155Mint(this._config, {
       address: this.assertValidAddress(),
@@ -43,7 +43,7 @@ export class MockERC1155 extends Deployable<unknown, typeof mockErc1155Abi> {
     address: Address,
     id: bigint,
     amount: bigint,
-    params: WriteParams<typeof mockErc1155Abi, 'burn'> = {},
+    params: WriteParams = {},
   ) {
     return await this.awaitResult(this.burnRaw(address, id, amount, params));
   }
@@ -52,7 +52,7 @@ export class MockERC1155 extends Deployable<unknown, typeof mockErc1155Abi> {
     address: Address,
     id: bigint,
     amount: bigint,
-    params: WriteParams<typeof mockErc1155Abi, 'burn'> = {},
+    params: WriteParams = {},
   ) {
     const { request, result } = await simulateMockErc1155Burn(this._config, {
       address: this.assertValidAddress(),

--- a/test/src/MockERC20.ts
+++ b/test/src/MockERC20.ts
@@ -19,10 +19,7 @@ import {
 import type { Address, Hex } from 'viem';
 
 export class MockERC20 extends Deployable<unknown, typeof mockErc20Abi> {
-  public async balanceOf(
-    account: Address,
-    params?: WriteParams<typeof mockErc20Abi, 'balanceOf'>,
-  ) {
+  public async balanceOf(account: Address, params?: WriteParams) {
     return await readMockErc20BalanceOf(this._config, {
       address: this.assertValidAddress(),
       args: [account],
@@ -34,7 +31,7 @@ export class MockERC20 extends Deployable<unknown, typeof mockErc20Abi> {
   public async allowance(
     owner: Address,
     spender: Address,
-    params?: WriteParams<typeof mockErc20Abi, 'allowance'>,
+    params?: WriteParams,
   ) {
     return await readMockErc20Allowance(this._config, {
       address: this.assertValidAddress(),
@@ -44,18 +41,14 @@ export class MockERC20 extends Deployable<unknown, typeof mockErc20Abi> {
     });
   }
 
-  public async approve(
-    address: Address,
-    value: bigint,
-    params?: WriteParams<typeof mockErc20Abi, 'approve'>,
-  ) {
+  public async approve(address: Address, value: bigint, params?: WriteParams) {
     return await this.awaitResult(this.approveRaw(address, value, params));
   }
 
   public async approveRaw(
     address: Address,
     value: bigint,
-    params?: WriteParams<typeof mockErc20Abi, 'approve'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateMockErc20Approve(this._config, {
       address: this.assertValidAddress(),
@@ -68,19 +61,11 @@ export class MockERC20 extends Deployable<unknown, typeof mockErc20Abi> {
     return { hash, result };
   }
 
-  public async mint(
-    address: Address,
-    value: bigint,
-    params?: WriteParams<typeof mockErc20Abi, 'mint'>,
-  ) {
+  public async mint(address: Address, value: bigint, params?: WriteParams) {
     return await this.awaitResult(this.mintRaw(address, value, params));
   }
 
-  public async mintRaw(
-    address: Address,
-    value: bigint,
-    params?: WriteParams<typeof mockErc20Abi, 'mint'>,
-  ) {
+  public async mintRaw(address: Address, value: bigint, params?: WriteParams) {
     const { request, result } = await simulateMockErc20Mint(this._config, {
       address: this.assertValidAddress(),
       args: [address, value],
@@ -95,7 +80,7 @@ export class MockERC20 extends Deployable<unknown, typeof mockErc20Abi> {
   public async mintPayable(
     address: Address,
     value: bigint,
-    params?: WriteParams<typeof mockErc20Abi, 'mintPayable'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(
       // biome-ignore lint/suspicious/noExplicitAny: this is a mock contract, it's fine
@@ -105,7 +90,7 @@ export class MockERC20 extends Deployable<unknown, typeof mockErc20Abi> {
   public async mintPayableRaw(
     address: Address,
     value: bigint,
-    params: WriteParams<typeof mockErc20Abi, 'mintPayable'>,
+    params: WriteParams,
   ) {
     const { request, result } = await simulateMockErc20MintPayable(
       this._config,

--- a/test/src/MockERC721.ts
+++ b/test/src/MockERC721.ts
@@ -17,18 +17,14 @@ import {
 import type { Address, Hex } from 'viem';
 
 export class MockERC721 extends Deployable<unknown, typeof mockErc721Abi> {
-  public async approve(
-    address: Address,
-    amount: bigint,
-    params?: WriteParams<typeof mockErc721Abi, 'approve'>,
-  ) {
+  public async approve(address: Address, amount: bigint, params?: WriteParams) {
     return await this.awaitResult(this.approveRaw(address, amount, params));
   }
 
   public async approveRaw(
     address: Address,
     amount: bigint,
-    params?: WriteParams<typeof mockErc721Abi, 'mint'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateMockErc721Approve(this._config, {
       address: this.assertValidAddress(),
@@ -45,7 +41,7 @@ export class MockERC721 extends Deployable<unknown, typeof mockErc721Abi> {
     from: Address,
     to: Address,
     id: bigint,
-    params?: WriteParams<typeof mockErc721Abi, 'transferFrom'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.transferFromRaw(from, to, id, params));
   }
@@ -54,7 +50,7 @@ export class MockERC721 extends Deployable<unknown, typeof mockErc721Abi> {
     from: Address,
     to: Address,
     id: bigint,
-    params?: WriteParams<typeof mockErc721Abi, 'transferFrom'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulateMockErc721TransferFrom(
       this._config,
@@ -70,17 +66,11 @@ export class MockERC721 extends Deployable<unknown, typeof mockErc721Abi> {
     return { hash, result };
   }
 
-  public async mint(
-    address: Address,
-    params?: WriteParams<typeof mockErc721Abi, 'mint'>,
-  ) {
+  public async mint(address: Address, params?: WriteParams) {
     return await this.awaitResult(this.mintRaw(address, params));
   }
 
-  public async mintRaw(
-    address: Address,
-    params?: WriteParams<typeof mockErc721Abi, 'mint'>,
-  ) {
+  public async mintRaw(address: Address, params?: WriteParams) {
     const { request, result } = await simulateMockErc721Mint(this._config, {
       address: this.assertValidAddress(),
       args: [address],

--- a/test/src/MockPoints.ts
+++ b/test/src/MockPoints.ts
@@ -18,7 +18,7 @@ export class MockPoints extends MockERC20 {
   public override async approve(
     address: Address,
     value: bigint,
-    params?: WriteParams<typeof pointsAbi, 'approve'>,
+    params?: WriteParams,
   ) {
     return await this.awaitResult(this.approveRaw(address, value, params));
   }
@@ -26,7 +26,7 @@ export class MockPoints extends MockERC20 {
   public override async approveRaw(
     address: Address,
     value: bigint,
-    params?: WriteParams<typeof pointsAbi, 'approve'>,
+    params?: WriteParams,
   ) {
     const { request, result } = await simulatePointsApprove(this._config, {
       address: this.assertValidAddress(),
@@ -39,19 +39,11 @@ export class MockPoints extends MockERC20 {
     return { hash, result };
   }
 
-  public async issue(
-    address: Address,
-    value: bigint,
-    params?: WriteParams<typeof pointsAbi, 'issue'>,
-  ) {
+  public async issue(address: Address, value: bigint, params?: WriteParams) {
     return await this.awaitResult(this.issueRaw(address, value, params));
   }
 
-  public async issueRaw(
-    address: Address,
-    value: bigint,
-    params?: WriteParams<typeof pointsAbi, 'issue'>,
-  ) {
+  public async issueRaw(address: Address, value: bigint, params?: WriteParams) {
     const { request, result } = await simulatePointsIssue(this._config, {
       address: this.assertValidAddress(),
       args: [address, value],


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
- use SimulateContractParameters instead of generic write params, it's more technically correct, as simulate accepts more state overrides.
- remove abi and names from generic read/write params interfaces, it really speeds up ts server for local development, makes tsdoc much more legible, and still satisfactory as far as interfaces go

💔 Thank you!
