### PR TITLE
[ADHOC] feat(cli): allow Validator to be optional in seed

### DIFF
--- a/.changeset/real-suns-explode.md
+++ b/.changeset/real-suns-explode.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/cli": minor
+---
+
+Make Validator and Allowlist optional in boost seed


### PR DESCRIPTION
### Description
- Make the Validator field optional in the seed configuration. If omitted, the default validator will be used.
- Make the Allowlist field optional in the seed configuration. If omitted, an open allowlist will be used.
- Fix type issues
- Remove unnecessary type assertions

These changes simplify the seed configuration by allowing users to omit the validator and allowlist settings when default behavior is desired.

💔 Thank you!
