### PR TITLE
[ADHOC] fix: add owner param to BoostCore constructor

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -97,8 +97,8 @@ contract BoostCore is Ownable, ReentrancyGuard {
     }
 
     /// @notice Constructor to initialize the owner
-    constructor(BoostRegistry registry_, address protocolFeeReceiver_) {
-        _initializeOwner(msg.sender);
+    constructor(BoostRegistry registry_, address protocolFeeReceiver_, address owner_) {
+        _initializeOwner(owner_);
         registry = registry_;
         protocolFeeReceiver = protocolFeeReceiver_;
     }

--- a/packages/evm/script/solidity/Deploy.s.sol
+++ b/packages/evm/script/solidity/Deploy.s.sol
@@ -29,8 +29,9 @@ contract CoreDeployer is ScriptUtils {
     }
 
     function _deployCore(address registry) internal returns (address core) {
+        address owner = vm.addr(vm.envUint("SIGNER_PRIVATE_KEY"));
         bytes memory initCode = type(BoostCore).creationCode;
-        bytes memory constructorArgs = abi.encode(registry, BOOST_FEE_RECIPIENT);
+        bytes memory constructorArgs = abi.encode(registry, BOOST_FEE_RECIPIENT, owner);
         core = _getCreate2Address(initCode, constructorArgs);
         console.log("BoostCore: ", core);
         _deploy2(initCode, constructorArgs);

--- a/packages/evm/script/solidity/Deploy.s.sol
+++ b/packages/evm/script/solidity/Deploy.s.sol
@@ -29,7 +29,7 @@ contract CoreDeployer is ScriptUtils {
     }
 
     function _deployCore(address registry) internal returns (address core) {
-        address owner = vm.addr(vm.envUint("SIGNER_PRIVATE_KEY"));
+        address owner = vm.envAddress("BOOST_CORE_OWNER_ADDRESS");
         bytes memory initCode = type(BoostCore).creationCode;
         bytes memory constructorArgs = abi.encode(registry, BOOST_FEE_RECIPIENT, owner);
         core = _getCreate2Address(initCode, constructorArgs);

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -44,7 +44,7 @@ contract BoostCoreTest is Test {
     MockAuth mockAuth;
     address[] mockAddresses;
 
-    BoostCore boostCore = new BoostCore(new BoostRegistry(), address(1));
+    BoostCore boostCore = new BoostCore(new BoostRegistry(), address(1), address(this));
     BoostLib.Target action =
         _makeERC721MintAction(address(mockERC721), MockERC721.mint.selector, mockERC721.mintPrice());
     BoostLib.Target contractAction =
@@ -95,7 +95,7 @@ contract BoostCoreTest is Test {
     function testConstructor() public {
         BoostRegistry registry = new BoostRegistry();
         address protocolFeeReceiver = address(1);
-        BoostCore boostCoreInstance = new BoostCore(registry, protocolFeeReceiver);
+        BoostCore boostCoreInstance = new BoostCore(registry, protocolFeeReceiver, address(this));
 
         // Check the owner
         assertEq(address(this), boostCoreInstance.owner());

--- a/packages/evm/test/e2e/EndToEndBasic.t.sol
+++ b/packages/evm/test/e2e/EndToEndBasic.t.sol
@@ -66,7 +66,7 @@ import {AValidator} from "contracts/validators/AValidator.sol";
  */
 contract EndToEndBasic is Test {
     BoostRegistry public registry = new BoostRegistry();
-    BoostCore public core = new BoostCore(registry, address(1));
+    BoostCore public core = new BoostCore(registry, address(1), address(this));
 
     MockERC20 public erc20 = new MockERC20();
     MockERC721 public erc721 = new MockERC721();

--- a/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
+++ b/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
@@ -36,7 +36,8 @@ import {AValidator} from "contracts/validators/AValidator.sol";
 contract EndToEndSignerValidator is Test, OwnableRoles {
     BoostRegistry public registry = new BoostRegistry();
     address fee_recipient = address(1);
-    BoostCore public core = new BoostCore(registry, fee_recipient);
+    address boost_core_owner = address(this);
+    BoostCore public core = new BoostCore(registry, fee_recipient, boost_core_owner);
 
     address budgetManager = makeAddr("ABudget Manager");
     address budgetAdmin = makeAddr("ABudget Admin");


### PR DESCRIPTION
### Description
Adds an owner param to the BoostCore constructor