### PR TITLE
[BOOST-5051] fix issues with `core.getBoost`

### DIFF
--- a/.changeset/short-spies-kiss.md
+++ b/.changeset/short-spies-kiss.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+pass params into internal reads on getBoost

--- a/packages/sdk/src/Actions/Action.ts
+++ b/packages/sdk/src/Actions/Action.ts
@@ -4,6 +4,7 @@ import { readContract } from '@wagmi/core';
 import type { Address, Hex } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
 import { InvalidComponentInterfaceError } from '../errors';
+import type { ReadParams } from '../utils';
 import { EventAction } from './EventAction';
 
 export {
@@ -44,11 +45,13 @@ export const ActionByComponentInterface = {
 export async function actionFromAddress(
   options: DeployableOptions,
   address: Address,
+  params?: ReadParams,
 ) {
   const interfaceId = (await readContract(options.config, {
     abi: aActionAbi,
     functionName: 'getComponentInterface',
     address,
+    ...params,
   })) as keyof typeof ActionByComponentInterface;
   const Ctor = ActionByComponentInterface[interfaceId];
   if (!Ctor) {

--- a/packages/sdk/src/AllowLists/AllowList.ts
+++ b/packages/sdk/src/AllowLists/AllowList.ts
@@ -7,6 +7,7 @@ import { readContract } from '@wagmi/core';
 import type { Address, Hex } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
 import { InvalidComponentInterfaceError } from '../errors';
+import type { ReadParams } from '../utils';
 import { OpenAllowList } from './OpenAllowList';
 import { SimpleAllowList } from './SimpleAllowList';
 import { SimpleDenyList } from './SimpleDenyList';
@@ -45,11 +46,13 @@ export const AllowListByComponentInterface = {
 export async function allowListFromAddress(
   options: DeployableOptions,
   address: Address,
+  params?: ReadParams,
 ) {
   const interfaceId = (await readContract(options.config, {
     abi: aAllowListAbi,
     functionName: 'getComponentInterface',
     address,
+    ...params,
   })) as keyof typeof AllowListByComponentInterface;
   const Ctor = AllowListByComponentInterface[interfaceId];
   if (!Ctor) {

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -810,13 +810,13 @@ export class BoostCore extends Deployable<
     };
     const [action, budget, validator, allowList, incentives] =
       await Promise.all([
-        actionFromAddress(options, boostPayload.action),
-        budgetFromAddress(options, boostPayload.budget),
-        validatorFromAddress(options, boostPayload.validator),
-        allowListFromAddress(options, boostPayload.allowList),
+        actionFromAddress(options, boostPayload.action, params),
+        budgetFromAddress(options, boostPayload.budget, params),
+        validatorFromAddress(options, boostPayload.validator, params),
+        allowListFromAddress(options, boostPayload.allowList, params),
         Promise.all(
           boostPayload.incentives.map((incentiveAddress) =>
-            incentiveFromAddress(options, incentiveAddress),
+            incentiveFromAddress(options, incentiveAddress, params),
           ),
         ),
       ]);

--- a/packages/sdk/src/Budgets/Budget.ts
+++ b/packages/sdk/src/Budgets/Budget.ts
@@ -7,6 +7,7 @@ import { readContract } from '@wagmi/core';
 import type { Address, Hex } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
 import { InvalidComponentInterfaceError } from '../errors';
+import type { ReadParams } from '../utils';
 import { ManagedBudget } from './ManagedBudget';
 import { ManagedBudgetWithFees } from './ManagedBudgetWithFees';
 
@@ -48,11 +49,13 @@ export const BudgetByComponentInterface = {
 export async function budgetFromAddress(
   options: DeployableOptions,
   address: Address,
+  params?: ReadParams,
 ) {
   const interfaceId = (await readContract(options.config, {
     abi: aBudgetAbi,
     functionName: 'getComponentInterface',
     address,
+    ...params,
   })) as keyof typeof BudgetByComponentInterface;
   const Ctor = BudgetByComponentInterface[interfaceId];
   if (!Ctor) {

--- a/packages/sdk/src/Incentives/Incentive.ts
+++ b/packages/sdk/src/Incentives/Incentive.ts
@@ -12,6 +12,7 @@ import { readContract } from '@wagmi/core';
 import type { Address, Hex } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
 import { InvalidComponentInterfaceError } from '../errors';
+import type { ReadParams } from '../utils';
 import { AllowListIncentive } from './AllowListIncentive';
 import { CGDAIncentive } from './CGDAIncentive';
 import { ERC20Incentive } from './ERC20Incentive';
@@ -73,11 +74,13 @@ export const IncentiveByComponentInterface = {
 export async function incentiveFromAddress(
   options: DeployableOptions,
   address: Address,
+  params?: ReadParams,
 ) {
   const interfaceId = (await readContract(options.config, {
     abi: aIncentiveAbi,
     functionName: 'getComponentInterface',
     address,
+    ...params,
   })) as keyof typeof IncentiveByComponentInterface;
   const Ctor = IncentiveByComponentInterface[interfaceId];
   if (!Ctor) {

--- a/packages/sdk/src/Validators/Validator.ts
+++ b/packages/sdk/src/Validators/Validator.ts
@@ -8,6 +8,7 @@ import { readContract } from '@wagmi/core';
 import { type Address, type Hex, decodeAbiParameters } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
 import { InvalidComponentInterfaceError } from '../errors';
+import type { ReadParams } from '../utils';
 import { LimitedSignerValidator } from './LimitedSignerValidator';
 import { SignerValidator } from './SignerValidator';
 
@@ -45,11 +46,13 @@ export const ValidatorByComponentInterface = {
 export async function validatorFromAddress(
   options: DeployableOptions,
   address: Address,
+  params?: ReadParams,
 ) {
   const interfaceId = (await readContract(options.config, {
     abi: aValidatorAbi,
     functionName: 'getComponentInterface',
     address,
+    ...params,
   })) as keyof typeof ValidatorByComponentInterface;
   const Ctor = ValidatorByComponentInterface[interfaceId];
   if (!Ctor) {


### PR DESCRIPTION
### Description
- fixes a bug were `core.getBoost` would error when targetting different chains using params.
` const boost = await core.getBoost(2n, { chainId: 84532 });`

Fix was to pass the params that are input to the getBoost method to internal contract reads.

💔 Thank you!
