### PR TITLE
[BOOST-4992] fix `incentive.isClaimable()` throws error

### DIFF
--- a/.changeset/quick-berries-decide.md
+++ b/.changeset/quick-berries-decide.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fix for isClaimable error on incentives

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -272,7 +272,7 @@ export class AllowListIncentive extends DeployableTarget<
   ) {
     return await readAllowListIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [prepareClaimPayload(payload)],
+      args: [payload.target, zeroHash],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -272,7 +272,7 @@ export class AllowListIncentive extends DeployableTarget<
   ) {
     return await readAllowListIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [payload.target, "0x"],
+      args: [payload.target, '0x'],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -272,7 +272,7 @@ export class AllowListIncentive extends DeployableTarget<
   ) {
     return await readAllowListIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [payload.target, zeroHash],
+      args: [payload.target, "0x"],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -375,7 +375,7 @@ export class CGDAIncentive extends DeployableTarget<
   public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readCgdaIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [prepareClaimPayload(payload)],
+      args: [payload.target, payload.data],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -359,7 +359,7 @@ export class ERC1155Incentive extends DeployableTarget<
   public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readErc1155IncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [prepareClaimPayload(payload)],
+      args: [payload.target, payload.data],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/ERC20Incentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.test.ts
@@ -39,6 +39,7 @@ describe("ERC20Incentive", () => {
       limit: 1n,
       manager: zeroAddress,
     });
+    // @ts-expect-error
     await action.deploy();
     expect(isAddress(action.assertValidAddress())).toBe(true);
   });
@@ -204,5 +205,53 @@ describe("ERC20Incentive", () => {
     expect(isAddressEqual(address, budgets.erc20.assertValidAddress())).toBe(
       true,
     );
+  });
+
+  test("isClaimable returns expected values", async () => {
+    const referrer = accounts[1].account;
+    const trustedSigner = accounts[0];
+    const erc20Incentive = fixtures.core.ERC20Incentive({
+      asset: budgets.erc20.assertValidAddress(),
+      strategy: StrategyType.POOL,
+      reward: 1n,
+      limit: 1n,
+      manager: budgets.budget.assertValidAddress(),
+    });
+    const boost = await freshBoost(fixtures, {
+      budget: budgets.budget,
+      incentives: [erc20Incentive],
+    });
+
+    const claimant = trustedSigner.account;
+    const incentiveData = erc20Incentive.buildClaimData();
+
+    // Should be claimable before claiming
+    expect(await boost.incentives.at(0)!.isClaimable({
+      target: claimant,
+      data: incentiveData
+    })).toBe(true);
+
+    const claimDataPayload = await boost.validator.encodeClaimData({
+      signer: trustedSigner,
+      incentiveData,
+      chainId: defaultOptions.config.chains[0].id,
+      incentiveQuantity: boost.incentives.length,
+      claimant,
+      boostId: boost.id,
+    });
+
+    // Claim the incentive
+    await fixtures.core.claimIncentive(
+      boost.id,
+      0n,
+      referrer,
+      claimDataPayload,
+    );
+
+    // Should not be claimable after claiming
+    expect(await boost.incentives.at(0)!.isClaimable({
+      target: claimant,
+      data: incentiveData
+    })).toBe(false);
   });
 });

--- a/packages/sdk/src/Incentives/ERC20Incentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.test.ts
@@ -226,7 +226,7 @@ describe("ERC20Incentive", () => {
     const incentiveData = erc20Incentive.buildClaimData();
 
     // Should be claimable before claiming
-    expect(await boost.incentives.at(0)!.isClaimable({
+    expect(await boost.incentives[0]!.isClaimable({
       target: claimant,
       data: incentiveData
     })).toBe(true);
@@ -249,7 +249,7 @@ describe("ERC20Incentive", () => {
     );
 
     // Should not be claimable after claiming
-    expect(await boost.incentives.at(0)!.isClaimable({
+    expect(await boost.incentives[0]!.isClaimable({
       target: claimant,
       data: incentiveData
     })).toBe(false);

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -373,7 +373,7 @@ export class ERC20Incentive extends DeployableTarget<
   public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readErc20IncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [prepareClaimPayload(payload)],
+      args: [payload.target, payload.data],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -346,7 +346,7 @@ export class ERC20VariableIncentive<
   public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readErc20VariableIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [prepareClaimPayload(payload)],
+      args: [payload.target, payload.data],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });

--- a/packages/sdk/src/Incentives/PointsIncentive.test.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.test.ts
@@ -180,10 +180,8 @@ describe("PointsIncentive", () => {
   });
 
   test("isClaimable returns expected values", async () => {
-    // biome-ignore lint/style/noNonNullAssertion: we know this is defined
-    const referrer = accounts.at(1)!.account!;
-    // biome-ignore lint/style/noNonNullAssertion: we know this is defined
-    const trustedSigner = accounts.at(0)!;
+    const referrer = accounts[1].account;
+    const trustedSigner = accounts[0];
     const pointsIncentive = fixtures.core.PointsIncentive({
       venue: points.assertValidAddress(),
       selector: bytes4("issue(address,uint256)"),
@@ -198,7 +196,7 @@ describe("PointsIncentive", () => {
     const incentiveData = pointsIncentive.buildClaimData();
 
     // Should be claimable before claiming
-    expect(await boost.incentives.at(0)!.isClaimable({
+    expect(await boost.incentives[0]!.isClaimable({
       target: claimant,
       data: incentiveData
     })).toBe(true);
@@ -225,7 +223,7 @@ describe("PointsIncentive", () => {
     );
 
     // Should not be claimable after claiming
-    expect(await boost.incentives.at(0)!.isClaimable({
+    expect(await boost.incentives[0]!.isClaimable({
       target: claimant,
       data: incentiveData
     })).toBe(false);

--- a/packages/sdk/src/Incentives/PointsIncentive.test.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.test.ts
@@ -32,6 +32,7 @@ describe("PointsIncentive", () => {
       reward: 1n,
       limit: 1n,
     });
+    // @ts-expect-error
     await action.deploy();
     expect(isAddress(action.assertValidAddress())).toBe(true);
   });
@@ -176,5 +177,57 @@ describe("PointsIncentive", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
     }
+  });
+
+  test("isClaimable returns expected values", async () => {
+    // biome-ignore lint/style/noNonNullAssertion: we know this is defined
+    const referrer = accounts.at(1)!.account!;
+    // biome-ignore lint/style/noNonNullAssertion: we know this is defined
+    const trustedSigner = accounts.at(0)!;
+    const pointsIncentive = fixtures.core.PointsIncentive({
+      venue: points.assertValidAddress(),
+      selector: bytes4("issue(address,uint256)"),
+      reward: 1n,
+      limit: 1n,
+    });
+    const boost = await freshBoost(fixtures, {
+      incentives: [pointsIncentive],
+    });
+
+    const claimant = trustedSigner.account;
+    const incentiveData = pointsIncentive.buildClaimData();
+
+    // Should be claimable before claiming
+    expect(await boost.incentives.at(0)!.isClaimable({
+      target: claimant,
+      data: incentiveData
+    })).toBe(true);
+
+    const claimDataPayload = await boost.validator.encodeClaimData({
+      signer: trustedSigner,
+      incentiveData,
+      chainId: defaultOptions.config.chains[0].id,
+      incentiveQuantity: boost.incentives.length,
+      claimant,
+      boostId: boost.id,
+    });
+
+    await writePointsGrantRoles(defaultOptions.config, {
+      address: points.assertValidAddress(),
+      args: [pointsIncentive.assertValidAddress(), 2n],
+      account: defaultOptions.account,
+    });
+    await fixtures.core.claimIncentive(
+      boost.id,
+      0n,
+      referrer,
+      claimDataPayload,
+    );
+
+    // Should not be claimable after claiming
+    expect(await boost.incentives.at(0)!.isClaimable({
+      target: claimant,
+      data: incentiveData
+    })).toBe(false);
   });
 });

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -290,7 +290,7 @@ export class PointsIncentive extends DeployableTarget<
   public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
     return await readPointsIncentiveIsClaimable(this._config, {
       address: this.assertValidAddress(),
-      args: [prepareClaimPayload(payload)],
+      args: [payload.target, payload.data],
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });


### PR DESCRIPTION
## Description
- fixes issue with `incentive.isClaimable()` throwing an error because of misconfigured arguments
- adds comprehensive tests for each incentive type

## Related Tickets
Linear Ticket: https://linear.app/rh-app/issue/BOOST-4992/fix-incentiveisclaimable-throws-error
Related Github Issue: https://github.com/boostxyz/boost-protocol/issues/278

💔 Thank you!
