### PR TITLE
[ADHOC] Fix block number validation

### DIFF
--- a/.changeset/shiny-pandas-rush.md
+++ b/.changeset/shiny-pandas-rush.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fixes block number validation

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -708,8 +708,12 @@ export class EventAction extends DeployableTarget<
         ...params,
         chainId: actionStep.chainid,
       });
-      if (params.notBeforeBlockNumber)
-        return receipt.blockNumber >= params.notBeforeBlockNumber;
+      if (
+        params.notBeforeBlockNumber &&
+        receipt.blockNumber < params.notBeforeBlockNumber
+      ) {
+        return false;
+      }
       const decodedLogs = receipt.logs
         .filter((log) => log.topics[0] === toEventSelector(event))
         .map((log) => {
@@ -730,8 +734,12 @@ export class EventAction extends DeployableTarget<
           ...params,
           chainId: actionStep.chainid,
         });
-        if (params.notBeforeBlockNumber)
-          return transaction.blockNumber >= params.notBeforeBlockNumber;
+        if (
+          params.notBeforeBlockNumber &&
+          transaction.blockNumber < params.notBeforeBlockNumber
+        ) {
+          return false;
+        }
         return this.isActionFunctionValid(actionStep, transaction, params);
       }
     }


### PR DESCRIPTION
### Description
Having a `notBeforeBlockNumber` param previously returned a boolean. We only care about returning false, otherwise continue validating the action step