### PR TITLE
[BOOST-4989] add public methods from `Ownable` to `DeployableTargetWithRBAC`

### DIFF
--- a/.changeset/spicy-monkeys-tease.md
+++ b/.changeset/spicy-monkeys-tease.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+Add ownership management methods to DeployableTargetWithRBAC

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
@@ -266,4 +266,14 @@ describe('RBAC', () => {
     // Check expiry after cancellation (should be 0 again)
     expect(await budget.ownershipHandoverExpiresAt(newOwner.account)).toBe(0n);
   });
+
+  test('can renounce roles', async () => {
+    const budget = await loadFixture(freshManagedBudget(defaultOptions, fixtures));
+    const account = accounts[0];
+    const user = account.account;
+    
+    expect(await budget.hasAllRoles(user, Roles.ADMIN)).toBe(true);
+    await budget.renounceRoles(Roles.ADMIN);
+    expect(await budget.hasAllRoles(user, Roles.ADMIN)).toBe(false);
+  });
 });

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
@@ -100,4 +100,17 @@ describe('RBAC', () => {
     expect(await budget.isAuthorized(user)).toBe(false);
     expect(await budget.rolesOf(user)).not.toContain(Roles.MANAGER);
   });
+
+  test('can transfer ownership', async () => {
+    const budget = await loadFixture(freshManagedBudget(defaultOptions, fixtures));
+    const oldOwner = accounts[0].account;
+    const newOwner = accounts[9].account;
+    expect(await budget.owner()).toBe(oldOwner);
+    
+    // Transfer ownership
+    await budget.transferOwnership(newOwner);
+    
+    // Verify the new owner has admin rights
+    expect(await budget.owner()).toBe(newOwner);
+  });
 });

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
@@ -115,7 +115,7 @@ describe('RBAC', () => {
     // Transfer ownership
     await budget.transferOwnership(newOwner);
     
-    // Verify the new owner has admin rights
+    // Verify the new owner
     expect(await budget.owner()).toBe(newOwner);
   });
 
@@ -123,7 +123,7 @@ describe('RBAC', () => {
     const budget = await loadFixture(freshManagedBudget(defaultOptions, fixtures));
     const owner = accounts[0].account;
     
-    // Verify initial owner has admin rights
+    // Verify initial owner
     expect(await budget.owner()).toBe(owner);
     
     // Renounce ownership
@@ -228,7 +228,6 @@ describe('RBAC', () => {
     const budget = await loadFixture(freshManagedBudget(defaultOptions, fixtures));
     const newOwner = accounts[6];
     
-    // Create new options with new owner's account and wallet client
     const walletClient = createTestClient({
       transport: http('http://127.0.0.1:8545', { retryCount: 0 }),
       chain: hardhat,
@@ -244,7 +243,7 @@ describe('RBAC', () => {
       config: setupConfig(walletClient)
     };
     
-    // Create budget instance with different signer
+    // Create identical budget instance with different signer
     const sameBudgetDifferentSigner = new ManagedBudget(
       { config: newOwnerOptions.config, account: newOwnerOptions.account },
       budget.address

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.test.ts
@@ -8,6 +8,7 @@ import {
   freshManagedBudget,
 } from '@boostxyz/test/helpers';
 import { Roles } from './DeployableTargetWithRBAC';
+import { zeroAddress } from 'viem';
 
 let fixtures: Fixtures;
 
@@ -112,5 +113,18 @@ describe('RBAC', () => {
     
     // Verify the new owner has admin rights
     expect(await budget.owner()).toBe(newOwner);
+  });
+
+  test('can renounce ownership', async () => {
+    const budget = await loadFixture(freshManagedBudget(defaultOptions, fixtures));
+    const owner = accounts[0].account;
+    
+    // Verify initial owner has admin rights
+    expect(await budget.owner()).toBe(owner);
+    
+    // Renounce ownership
+    await budget.renounceOwnership();
+    const newOwner = await budget.owner();
+    expect(newOwner).toBe(zeroAddress);
   });
 });

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -4,12 +4,14 @@ import {
   readRbacHasAnyRole,
   readRbacIsAuthorized,
   readRbacRolesOf,
+  simulateOwnableRolesRenounceOwnership,
   simulateOwnableRolesTransferOwnership,
   simulateRbacGrantManyRoles,
   simulateRbacGrantRoles,
   simulateRbacRevokeManyRoles,
   simulateRbacRevokeRoles,
   simulateRbacSetAuthorized,
+  writeOwnableRolesRenounceOwnership,
   writeOwnableRolesTransferOwnership,
   writeRbacGrantManyRoles,
   writeRbacGrantRoles,
@@ -463,6 +465,43 @@ export class DeployableTargetWithRBAC<
       },
     );
     const hash = await writeOwnableRolesTransferOwnership(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Renounce ownership of the contract
+   *
+   * @public
+   * @async
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async renounceOwnership(params?: WriteParams) {
+    return await this.awaitResult(this.renounceOwnershipRaw(params));
+  }
+
+  /**
+   * Renounce ownership of the contract
+   *
+   * @public
+   * @async
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async renounceOwnershipRaw(params?: WriteParams) {
+    const { request, result } = await simulateOwnableRolesRenounceOwnership(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOwnableRolesRenounceOwnership(
       this._config,
       request,
     );

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -4,11 +4,13 @@ import {
   readRbacHasAnyRole,
   readRbacIsAuthorized,
   readRbacRolesOf,
+  simulateOwnableRolesTransferOwnership,
   simulateRbacGrantManyRoles,
   simulateRbacGrantRoles,
   simulateRbacRevokeManyRoles,
   simulateRbacRevokeRoles,
   simulateRbacSetAuthorized,
+  writeOwnableRolesTransferOwnership,
   writeRbacGrantManyRoles,
   writeRbacGrantRoles,
   writeRbacRevokeManyRoles,
@@ -425,5 +427,45 @@ export class DeployableTargetWithRBAC<
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });
+  }
+
+  /**
+   * Transfer ownership of the contract to a new address
+   *
+   * @public
+   * @async
+   * @param {Address} newOwner - The address to transfer ownership to
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async transferOwnership(newOwner: Address, params?: WriteParams) {
+    return await this.awaitResult(this.transferOwnershipRaw(newOwner, params));
+  }
+
+  /**
+   * Transfer ownership of the contract to a new address
+   *
+   * @public
+   * @async
+   * @param {Address} newOwner - The address to transfer ownership to
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async transferOwnershipRaw(newOwner: Address, params?: WriteParams) {
+    const { request, result } = await simulateOwnableRolesTransferOwnership(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [newOwner],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOwnableRolesTransferOwnership(
+      this._config,
+      request,
+    );
+    return { hash, result };
   }
 }

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -8,6 +8,7 @@ import {
   simulateOwnableRolesCancelOwnershipHandover,
   simulateOwnableRolesCompleteOwnershipHandover,
   simulateOwnableRolesRenounceOwnership,
+  simulateOwnableRolesRenounceRoles,
   simulateOwnableRolesRequestOwnershipHandover,
   simulateOwnableRolesTransferOwnership,
   simulateRbacGrantManyRoles,
@@ -18,6 +19,7 @@ import {
   writeOwnableRolesCancelOwnershipHandover,
   writeOwnableRolesCompleteOwnershipHandover,
   writeOwnableRolesRenounceOwnership,
+  writeOwnableRolesRenounceRoles,
   writeOwnableRolesRequestOwnershipHandover,
   writeOwnableRolesTransferOwnership,
   writeRbacGrantManyRoles,
@@ -665,5 +667,44 @@ export class DeployableTargetWithRBAC<
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
     });
+  }
+
+  /**
+   * Allow the caller to remove their own roles
+   * If the caller does not have a role, then it will be a no-op for that role
+   *
+   * @public
+   * @async
+   * @param {Roles} roles - Bitmap of roles to renounce
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async renounceRoles(roles: Roles, params?: WriteParams) {
+    return await this.awaitResult(this.renounceRolesRaw(roles, params));
+  }
+
+  /**
+   * Allow the caller to remove their own roles
+   * If the caller does not have a role, then it will be a no-op for that role
+   *
+   * @public
+   * @async
+   * @param {Roles} roles - Bitmap of roles to renounce
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async renounceRolesRaw(roles: Roles, params?: WriteParams) {
+    const { request, result } = await simulateOwnableRolesRenounceRoles(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [roles],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOwnableRolesRenounceRoles(this._config, request);
+    return { hash, result };
   }
 }

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -1,5 +1,6 @@
 import {
   rbacAbi,
+  readOwnableRolesOwnershipHandoverExpiresAt,
   readRbacHasAllRoles,
   readRbacHasAnyRole,
   readRbacIsAuthorized,
@@ -642,5 +643,27 @@ export class DeployableTargetWithRBAC<
       request,
     );
     return { hash, result };
+  }
+
+  /**
+   * Get the expiry timestamp for a pending ownership handover
+   * Returns 0 if there is no pending handover request for the given address
+   *
+   * @public
+   * @param {Address} pendingOwner - The address to check for pending handover requests
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>} - The timestamp when the handover request expires, or 0 if no request exists
+   */
+  public ownershipHandoverExpiresAt(
+    pendingOwner: Address,
+    params?: ReadParams,
+  ): Promise<bigint> {
+    return readOwnableRolesOwnershipHandoverExpiresAt(this._config, {
+      address: this.assertValidAddress(),
+      args: [pendingOwner],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
   }
 }

--- a/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
+++ b/packages/sdk/src/Deployable/DeployableTargetWithRBAC.ts
@@ -4,6 +4,7 @@ import {
   readRbacHasAnyRole,
   readRbacIsAuthorized,
   readRbacRolesOf,
+  simulateOwnableRolesCancelOwnershipHandover,
   simulateOwnableRolesCompleteOwnershipHandover,
   simulateOwnableRolesRenounceOwnership,
   simulateOwnableRolesRequestOwnershipHandover,
@@ -13,6 +14,7 @@ import {
   simulateRbacRevokeManyRoles,
   simulateRbacRevokeRoles,
   simulateRbacSetAuthorized,
+  writeOwnableRolesCancelOwnershipHandover,
   writeOwnableRolesCompleteOwnershipHandover,
   writeOwnableRolesRenounceOwnership,
   writeOwnableRolesRequestOwnershipHandover,
@@ -599,6 +601,43 @@ export class DeployableTargetWithRBAC<
         ...(params as any),
       });
     const hash = await writeOwnableRolesCompleteOwnershipHandover(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Cancel a pending ownership handover request
+   * Must be called by the account that originally requested the handover
+   *
+   * @public
+   * @async
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async cancelOwnershipHandover(params?: WriteParams) {
+    return await this.awaitResult(this.cancelOwnershipHandoverRaw(params));
+  }
+
+  /**
+   * Cancel a pending ownership handover request
+   * Must be called by the account that originally requested the handover
+   *
+   * @public
+   * @async
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async cancelOwnershipHandoverRaw(params?: WriteParams) {
+    const { request, result } =
+      await simulateOwnableRolesCancelOwnershipHandover(this._config, {
+        address: this.assertValidAddress(),
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      });
+    const hash = await writeOwnableRolesCancelOwnershipHandover(
       this._config,
       request,
     );


### PR DESCRIPTION
### Description
- adds the following methods to `DeployableTargetWithRBAC`
  - `transferOwnership`
  - `renounceOwnership`
  - `requestOwnershipHandover`
  - `completeOwnershipHandover`
  - `cancelOwnershipHandover`
  - `ownershipHandoverExpiresAt`
  - `renounceRoles`

- adds tests for each new method to ensure they are working as expected

💔 Thank you!
