### PR TITLE
[BOOST-5055] feat(evm/sdk): fork existing erc20 incentive and add peg token

### DIFF
--- a/packages/evm/contracts/incentives/AERC20PeggedIncentive.sol
+++ b/packages/evm/contracts/incentives/AERC20PeggedIncentive.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {LibPRNG} from "@solady/utils/LibPRNG.sol";
+import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
+
+import {ACloneable} from "contracts/shared/ACloneable.sol";
+import {BoostError} from "contracts/shared/BoostError.sol";
+
+import {ABudget} from "contracts/budgets/ABudget.sol";
+import {AIncentive} from "./AIncentive.sol";
+
+/// @title ERC20 AIncentive
+/// @notice A simple ERC20 incentive implementation that allows claiming of tokens
+abstract contract AERC20PeggedIncentive is AIncentive {
+    using LibPRNG for LibPRNG.PRNG;
+    using SafeTransferLib for address;
+
+    /// @notice A mapping of address to claim status
+    mapping(address => bool) public claimed;
+
+    uint256 public totalClaim;
+
+    /// @notice The limit (max claims, or max entries for raffles)
+    function limit() external virtual returns (uint256);
+
+    /// @inheritdoc ACloneable
+    function getComponentInterface() public pure virtual override(ACloneable) returns (bytes4) {
+        return type(AERC20PeggedIncentive).interfaceId;
+    }
+
+    /// @notice The asset for the peg
+    /// @dev The asset is the token that the peg is based on
+    /// @return The asset address
+    function getPeg() external view virtual returns (address);
+
+    /// @notice The total amount claimed so far
+    function totalClaimed() external virtual returns (uint256);
+
+    /// @inheritdoc ACloneable
+    function supportsInterface(bytes4 interfaceId) public view virtual override(AIncentive) returns (bool) {
+        return interfaceId == type(AERC20PeggedIncentive).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/packages/evm/contracts/incentives/AERC20PeggedIncentive.sol
+++ b/packages/evm/contracts/incentives/AERC20PeggedIncentive.sol
@@ -21,7 +21,7 @@ abstract contract AERC20PeggedIncentive is AIncentive {
 
     uint256 public totalClaim;
 
-    /// @notice The limit (max claims, or max entries for raffles)
+    /// @notice The limit max possible reward tokens to be claimed
     function limit() external virtual returns (uint256);
 
     /// @inheritdoc ACloneable

--- a/packages/evm/contracts/incentives/AERC20PeggedIncentive.sol
+++ b/packages/evm/contracts/incentives/AERC20PeggedIncentive.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
-import {LibPRNG} from "@solady/utils/LibPRNG.sol";
 import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 
 import {ACloneable} from "contracts/shared/ACloneable.sol";
@@ -13,7 +12,6 @@ import {AIncentive} from "./AIncentive.sol";
 /// @title ERC20 AIncentive
 /// @notice A simple ERC20 incentive implementation that allows claiming of tokens
 abstract contract AERC20PeggedIncentive is AIncentive {
-    using LibPRNG for LibPRNG.PRNG;
     using SafeTransferLib for address;
 
     /// @notice A mapping of address to claim status

--- a/packages/evm/contracts/incentives/ERC20PeggedIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20PeggedIncentive.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
-import {LibPRNG} from "@solady/utils/LibPRNG.sol";
 import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 
 import {BoostError} from "contracts/shared/BoostError.sol";
@@ -12,7 +11,6 @@ import {ABudget} from "contracts/budgets/ABudget.sol";
 import {RBAC} from "contracts/shared/RBAC.sol";
 
 contract ERC20PeggedIncentive is RBAC, AERC20PeggedIncentive {
-    using LibPRNG for LibPRNG.PRNG;
     using SafeTransferLib for address;
 
     event ERC20PeggedIncentiveInitialized(

--- a/packages/evm/contracts/incentives/ERC20PeggedIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20PeggedIncentive.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {LibPRNG} from "@solady/utils/LibPRNG.sol";
+import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
+
+import {BoostError} from "contracts/shared/BoostError.sol";
+
+import {AERC20PeggedIncentive} from "contracts/incentives/AERC20PeggedIncentive.sol";
+import {AIncentive} from "contracts/incentives/AIncentive.sol";
+import {ABudget} from "contracts/budgets/ABudget.sol";
+import {RBAC} from "contracts/shared/RBAC.sol";
+
+contract ERC20PeggedIncentive is RBAC, AERC20PeggedIncentive {
+    using LibPRNG for LibPRNG.PRNG;
+    using SafeTransferLib for address;
+
+    event ERC20PeggedIncentiveInitialized(
+        address indexed asset, address indexed peg, uint256 reward, uint256 limit, address manager
+    );
+
+    /// @notice The payload for initializing the incentive
+    struct InitPayload {
+        address asset;
+        address peg;
+        uint256 reward;
+        uint256 limit;
+        address manager;
+    }
+
+    /// @inheritdoc AIncentive
+    address public override asset;
+
+    /// @inheritdoc AIncentive
+    uint256 public override claims;
+
+    /// @inheritdoc AERC20PeggedIncentive
+    uint256 public override limit;
+
+    /// @inheritdoc AERC20PeggedIncentive
+    uint256 public override totalClaimed;
+
+    // Asset for the peg
+    address public peg;
+
+    /// @notice Construct a new ERC20Incentive
+    /// @dev Because this contract is a base implementation, it should not be initialized through the constructor. Instead, it should be cloned and initialized using the {initialize} function.
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the contract with the incentive parameters
+    /// @param data_ The compressed incentive parameters `(address asset, Strategy strategy, uint256 reward, uint256 limit)`
+    function initialize(bytes calldata data_) public override initializer {
+        InitPayload memory init_ = abi.decode(data_, (InitPayload));
+
+        if (init_.reward == 0 || init_.limit == 0) revert BoostError.InvalidInitialization();
+
+        // Ensure the maximum reward amount has been allocated
+        uint256 maxTotalReward = init_.limit;
+        uint256 available = init_.asset.balanceOf(address(this));
+        if (available < maxTotalReward) {
+            revert BoostError.InsufficientFunds(init_.asset, available, maxTotalReward);
+        }
+
+        asset = init_.asset;
+        peg = init_.peg;
+        reward = init_.reward;
+        limit = init_.limit;
+        _initializeOwner(msg.sender);
+        _setRoles(init_.manager, MANAGER_ROLE);
+        emit ERC20PeggedIncentiveInitialized(init_.asset, init_.peg, init_.reward, init_.limit, init_.manager);
+    }
+
+    /// @inheritdoc AIncentive
+    /// @notice Preflight the incentive to determine the required budget action
+    /// @param data_ The {InitPayload} for the incentive
+    /// @return budgetData The {Transfer} payload to be passed to the {ABudget} for interpretation
+    function preflight(bytes calldata data_) external view override returns (bytes memory budgetData) {
+        InitPayload memory init_ = abi.decode(data_, (InitPayload));
+        uint256 amount = init_.limit;
+
+        return abi.encode(
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC20,
+                asset: init_.asset,
+                target: address(this),
+                data: abi.encode(ABudget.FungiblePayload({amount: amount}))
+            })
+        );
+    }
+
+    /// @notice Claim the incentive with variable rewards
+    /// @param data_ The data payload for the incentive claim `(uint256signedAmount)`
+    /// @return True if the incentive was successfully claimed
+    function claim(address claimTarget, bytes calldata data_) external virtual override onlyOwner returns (bool) {
+        BoostClaimData memory boostClaimData = abi.decode(data_, (BoostClaimData));
+        uint256 signedAmount = abi.decode(boostClaimData.incentiveData, (uint256));
+
+        if (!_isClaimable(claimTarget, signedAmount)) revert NotClaimable();
+
+        if (totalClaimed + signedAmount > limit) revert ClaimFailed();
+
+        totalClaimed += signedAmount;
+        claims += 1;
+        asset.safeTransfer(claimTarget, signedAmount);
+
+        emit Claimed(claimTarget, abi.encodePacked(asset, claimTarget, signedAmount));
+        return true;
+    }
+
+    /// @inheritdoc AIncentive
+    function clawback(bytes calldata data_) external override onlyRoles(MANAGER_ROLE) returns (uint256, address) {
+        ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
+        (uint256 amount) = abi.decode(claim_.data, (uint256));
+
+        limit -= amount;
+
+        // Transfer the tokens back to the intended recipient
+        asset.safeTransfer(claim_.target, amount);
+        emit Claimed(claim_.target, abi.encodePacked(asset, claim_.target, amount));
+
+        return (amount, asset);
+    }
+
+    /// @notice Check if an incentive is claimable
+    /// @param claimTarget the address that could receive the claim
+    /// @return True if the incentive is claimable based on the data payload
+    /// @dev For the POOL strategy, the `bytes data` portion of the payload ignored
+    /// @dev The recipient must not have already claimed the incentive
+    function isClaimable(address claimTarget, bytes calldata data_) public view override returns (bool) {
+        BoostClaimData memory boostClaimData = abi.decode(data_, (BoostClaimData));
+        uint256 signedAmount = abi.decode(boostClaimData.incentiveData, (uint256));
+
+        return _isClaimable(claimTarget, signedAmount);
+    }
+
+    /// @notice Check if an incentive is claimable for a specific recipient
+    /// @param recipient_ The address of the recipient
+    /// @return True if the incentive is claimable for the recipient
+    function _isClaimable(address recipient_, uint256 amount) internal view returns (bool) {
+        return !claimed[recipient_] && (totalClaimed + amount) <= limit;
+    }
+
+    function getPeg() external view override returns (address) {
+        return peg;
+    }
+}

--- a/packages/evm/script/solidity/ComponentInterface.s.sol
+++ b/packages/evm/script/solidity/ComponentInterface.s.sol
@@ -19,6 +19,7 @@ import {AEventAction} from "contracts/actions/EventAction.sol";
 import {AAllowListIncentive} from "contracts/incentives/AllowListIncentive.sol";
 import {ACGDAIncentive} from "contracts/incentives/CGDAIncentive.sol";
 import {AERC20Incentive} from "contracts/incentives/ERC20Incentive.sol";
+import {AERC20PeggedIncentive} from "contracts/incentives/AERC20PeggedIncentive.sol";
 import {AIncentive} from "contracts/incentives/AIncentive.sol";
 import {AERC20VariableIncentive} from "contracts/incentives/ERC20VariableIncentive.sol";
 import {AERC20VariableCriteriaIncentive} from "contracts/incentives/AERC20VariableCriteriaIncentive.sol";
@@ -37,6 +38,7 @@ contract LogComponentInterface is ScriptUtils {
     function run() public {
         _getInterfaceAEventAction();
         _getInterfaceAERC20Incentive();
+        _getInterfaceAERC20PeggedIncentive();
         _getInterfaceACloneable();
         _getInterfaceABudget();
         _getInterfaceAManagedBudget();
@@ -116,6 +118,11 @@ contract LogComponentInterface is ScriptUtils {
     function _getInterfaceAIncentive() internal {
         string memory interfaceId = uint256(uint32(type(AIncentive).interfaceId)).toHexString(4);
         componentJson = componentJsonKey.serialize("AIncentive", interfaceId);
+    }
+
+    function _getInterfaceAERC20PeggedIncentive() internal {
+        string memory interfaceId = uint256(uint32(type(AERC20PeggedIncentive).interfaceId)).toHexString(4);
+        componentJson = componentJsonKey.serialize("AERC20PeggedIncentive", interfaceId);
     }
 
     function _getInterfaceAERC20VariableIncentive() internal {

--- a/packages/evm/script/solidity/Deploy_Modules.s.sol
+++ b/packages/evm/script/solidity/Deploy_Modules.s.sol
@@ -14,6 +14,7 @@ import {ManagedBudgetWithFees} from "contracts/budgets/ManagedBudgetWithFees.sol
 import {EventAction} from "contracts/actions/EventAction.sol";
 
 import {ERC20Incentive} from "contracts/incentives/ERC20Incentive.sol";
+import {ERC20PeggedIncentive} from "contracts/incentives/ERC20PeggedIncentive.sol";
 import {ERC20VariableIncentive} from "contracts/incentives/ERC20VariableIncentive.sol";
 import {ERC20VariableCriteriaIncentive} from "contracts/incentives/ERC20VariableCriteriaIncentive.sol";
 import {CGDAIncentive} from "contracts/incentives/CGDAIncentive.sol";
@@ -111,6 +112,15 @@ contract ModuleBaseDeployer is ScriptUtils {
         deployJson = deployJsonKey.serialize("ERC20Incentive", erc20Incentive);
         bool newDeploy = _deploy2(initCode, "");
         _registerIfNew(newDeploy, "ERC20Incentive", erc20Incentive, registry, ABoostRegistry.RegistryType.INCENTIVE);
+    }
+
+function _deployERC20PeggedIncentive(BoostRegistry registry) internal returns (address erc20PeggedIncentive) {
+        bytes memory initCode = type(ERC20PeggedIncentive).creationCode;
+        erc20PeggedIncentive = _getCreate2Address(initCode, "");
+        console.log("ERC20PeggedIncentive: ", erc20PeggedIncentive);
+        deployJson = deployJsonKey.serialize("ERC20PeggedIncentive", erc20PeggedIncentive);
+        bool newDeploy = _deploy2(initCode, "");
+        _registerIfNew(newDeploy, "ERC20PeggedIncentive", erc20PeggedIncentive, registry, ABoostRegistry.RegistryType.INCENTIVE);
     }
 
     function _deployERC20VariableIncentive(BoostRegistry registry) internal returns (address erc20VariableIncentive) {

--- a/packages/evm/test/incentives/ERC20PeggedIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20PeggedIncentive.t.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Test, console} from "lib/forge-std/src/Test.sol";
+import {MockERC20} from "contracts/shared/Mocks.sol";
+import {LibClone} from "@solady/utils/LibClone.sol";
+import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
+
+import {BoostError} from "contracts/shared/BoostError.sol";
+import {AIncentive, IBoostClaim} from "contracts/incentives/AIncentive.sol";
+import {ERC20PeggedIncentive} from "contracts/incentives/ERC20PeggedIncentive.sol";
+import {AERC20PeggedIncentive} from "contracts/incentives/AERC20PeggedIncentive.sol";
+
+import {ABudget} from "contracts/budgets/ABudget.sol";
+import {ManagedBudget} from "contracts/budgets/ManagedBudget.sol";
+
+contract ERC20PeggedIncentiveTest is Test {
+    using SafeTransferLib for address;
+
+    ERC20PeggedIncentive public incentive;
+    ManagedBudget public budget;
+    MockERC20 public mockAsset = new MockERC20();
+    MockERC20 public pegAsset = new MockERC20();
+
+    function setUp() public {
+        incentive = _newIncentiveClone();
+        budget = _newBudgetClone();
+
+        // Preload the budget with some mock tokens
+        mockAsset.mint(address(this), 100 ether);
+        mockAsset.approve(address(budget), 100 ether);
+        budget.allocate(_makeFungibleTransfer(ABudget.AssetType.ERC20, address(mockAsset), address(this), 100 ether));
+
+        // Manually handle the budget disbursement
+        budget.disburse(
+            _makeFungibleTransfer(ABudget.AssetType.ERC20, address(mockAsset), address(incentive), 100 ether)
+        );
+    }
+
+    ///////////////////////////////////////
+    // ERC20PeggedIncentive.initialize //
+    ///////////////////////////////////////
+
+    function testInitialize() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Check the incentive parameters
+        assertEq(incentive.asset(), address(mockAsset));
+        assertEq(incentive.getPeg(), address(pegAsset));
+        assertEq(incentive.reward(), 1 ether);
+        assertEq(incentive.limit(), 5 ether);
+    }
+
+    function testInitialize_InsufficientFunds() public {
+        // Attempt to initialize with a limit greater than available balance => revert
+        vm.expectRevert(
+            abi.encodeWithSelector(BoostError.InsufficientFunds.selector, address(mockAsset), 100 ether, 101 ether)
+        );
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 101 ether, address(this));
+    }
+
+    function testInitialize_InvalidInitialization() public {
+        // Attempt to initialize with invalid parameters => revert
+        vm.expectRevert(BoostError.InvalidInitialization.selector);
+        _initialize(address(mockAsset), address(pegAsset), 0, 0, address(this));
+    }
+
+    //////////////////////////////////
+    // ERC20PeggedIncentive.claim //
+    //////////////////////////////////
+
+    function testClaim() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        vm.expectEmit(true, false, false, true);
+        emit AIncentive.Claimed(address(this), abi.encodePacked(address(mockAsset), address(this), uint256(1 ether)));
+
+        // Claim the incentive
+        incentive.claim(address(this), _encodeBoostClaim(1 ether));
+
+        // Check the claim status and balance
+        assertEq(mockAsset.balanceOf(address(this)), 1 ether);
+        assertFalse(incentive.isClaimable(address(this), _encodeBoostClaim(5 ether)));
+        assertEq(incentive.totalClaimed(), 1 ether);
+        assertEq(incentive.claims(), 1);
+    }
+
+    function testClaim_NotClaimable() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Claim the incentive
+        incentive.claim(address(this), _encodeBoostClaim(1 ether));
+
+        // Attempt to claim again => revert
+        vm.expectRevert(AIncentive.NotClaimable.selector);
+        incentive.claim(address(this), _encodeBoostClaim(6 ether));
+    }
+
+    function testClaim_ExceedsLimit() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Attempt to claim more than the limit in a single claim => revert
+        vm.expectRevert(AIncentive.NotClaimable.selector);
+        incentive.claim(address(this), _encodeBoostClaim(6 ether));
+    }
+
+    //////////////////////////////////////
+    // ERC20PeggedIncentive.preflight //
+    //////////////////////////////////////
+
+    function testPreflight() public {
+        bytes memory preflightPayload = incentive.preflight(
+            abi.encode(
+                ERC20PeggedIncentive.InitPayload({
+                    asset: address(mockAsset),
+                    peg: address(pegAsset),
+                    reward: 1 ether,
+                    limit: 5 ether,
+                    manager: address(this)
+                })
+            )
+        );
+
+        ABudget.Transfer memory transfer = abi.decode(preflightPayload, (ABudget.Transfer));
+        assertEq(transfer.asset, address(mockAsset));
+        assertEq(transfer.target, address(incentive));
+        assertEq(abi.decode(transfer.data, (ABudget.FungiblePayload)).amount, 5 ether);
+    }
+
+    ////////////////////////////////////
+    // ERC20PeggedIncentive.clawback //
+    ////////////////////////////////////
+
+    function testClawback() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Clawback some tokens
+        bytes memory reclaimPayload =
+            abi.encode(AIncentive.ClawbackPayload({target: address(this), data: abi.encode(2 ether)}));
+        incentive.clawback(reclaimPayload);
+
+        // Check the balance and limit
+        assertEq(mockAsset.balanceOf(address(this)), 2 ether);
+        assertEq(incentive.limit(), 3 ether);
+    }
+
+    function testClawback_Unauthorized() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Attempt to call clawback from an unauthorized address
+        address unauthorized = address(0x1234);
+        vm.prank(unauthorized);
+        bytes memory reclaimPayload =
+            abi.encode(AIncentive.ClawbackPayload({target: address(this), data: abi.encode(2 ether)}));
+        vm.expectRevert(BoostError.Unauthorized.selector);
+        incentive.clawback(reclaimPayload);
+    }
+
+    function testGetPeg() public {
+        // Initialize the ERC20PeggedIncentive
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Check the peg address
+        assertEq(incentive.getPeg(), address(pegAsset));
+    }
+
+    //////////////////////////////////////////////////
+    // ERC20PeggedIncentive.getComponentInterface //
+    //////////////////////////////////////////////////
+
+    function testGetComponentInterface() public view {
+        // Retrieve the component interface
+        console.logBytes4(incentive.getComponentInterface());
+        assertEq(incentive.getComponentInterface(), type(AERC20PeggedIncentive).interfaceId);
+    }
+
+    //////////////////////////////////////////////
+    // ERC20PeggedIncentive.supportsInterface //
+    //////////////////////////////////////////////
+
+    function testSupportsInterface() public view {
+        // Ensure the contract supports the AIncentive interface
+        assertTrue(incentive.supportsInterface(type(AIncentive).interfaceId));
+    }
+
+    function testSupportsInterface_NotSupported() public view {
+        // Ensure the contract does not support an unsupported interface
+        assertFalse(incentive.supportsInterface(type(Test).interfaceId));
+    }
+
+    ///////////////////////////
+    // Test Helper Functions //
+    ///////////////////////////
+
+    function _newIncentiveClone() internal returns (ERC20PeggedIncentive) {
+        return ERC20PeggedIncentive(LibClone.clone(address(new ERC20PeggedIncentive())));
+    }
+
+    function _newBudgetClone() internal returns (ManagedBudget newBudget) {
+        address[] memory authorized = new address[](0);
+        uint256[] memory roles = new uint256[](0);
+        ManagedBudget.InitPayload memory initPayload = ManagedBudget.InitPayload(address(this), authorized, roles);
+        newBudget = ManagedBudget(payable(LibClone.clone(address(new ManagedBudget()))));
+        newBudget.initialize(abi.encode(initPayload));
+    }
+
+    function _initialize(address asset, address peg, uint256 reward, uint256 limit, address manager) internal {
+        incentive.initialize(_initPayload(asset, peg, reward, limit, manager));
+    }
+
+    function _initPayload(address asset, address peg, uint256 reward, uint256 limit, address manager)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(
+            ERC20PeggedIncentive.InitPayload({asset: asset, peg: peg, reward: reward, limit: limit, manager: manager})
+        );
+    }
+
+    function _makeFungibleTransfer(ABudget.AssetType assetType, address asset, address target, uint256 value)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        ABudget.Transfer memory transfer;
+        transfer.assetType = assetType;
+        transfer.asset = asset;
+        transfer.target = target;
+        transfer.data = abi.encode(ABudget.FungiblePayload({amount: value}));
+
+        return abi.encode(transfer);
+    }
+
+    function _encodeBoostClaim(uint256 amount) internal pure returns (bytes memory data) {
+        return abi.encode(IBoostClaim.BoostClaimData(hex"", abi.encode(amount)));
+    }
+}

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -83,6 +83,10 @@ import {
   type ERC20IncentivePayload,
 } from './Incentives/ERC20Incentive';
 import {
+  ERC20PeggedIncentive,
+  type ERC20PeggedIncentivePayload,
+} from './Incentives/ERC20PeggedIncentive';
+import {
   ERC20VariableCriteriaIncentive,
   type ERC20VariableCriteriaIncentivePayload,
 } from './Incentives/ERC20VariableCriteriaIncentive';
@@ -1367,6 +1371,24 @@ export class BoostCore extends Deployable<
    */
   ERC20Incentive(options: ERC20IncentivePayload) {
     return new ERC20Incentive(
+      { config: this._config, account: this._account },
+      options,
+    );
+  }
+
+  /**
+   * Bound {@link ERC20PeggedIncentive} constructor that reuses the same configuration as the Boost Core instance.
+   *
+   * @example
+   * ```ts
+   * const incentive = core.ERC20PeggedIncentive({ ... }) // is roughly equivalent to
+   * const incentive = new ERC20PeggedIncentive({ config: core._config, account: core._account }, { ... })
+   * ```
+   * @param {ERC20PeggedIncentivePayload} options
+   * @returns {ERC20PeggedIncentive}
+   */
+  ERC20PeggedIncentive(options: ERC20PeggedIncentivePayload) {
+    return new ERC20PeggedIncentive(
       { config: this._config, account: this._account },
       options,
     );

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -1,0 +1,490 @@
+import {
+  erc20PeggedIncentiveAbi,
+  readErc20PeggedIncentiveAsset,
+  readErc20PeggedIncentiveClaimed,
+  readErc20PeggedIncentiveClaims,
+  readErc20PeggedIncentiveCurrentReward,
+  readErc20PeggedIncentiveGetPeg,
+  readErc20PeggedIncentiveIsClaimable,
+  readErc20PeggedIncentiveLimit,
+  readErc20PeggedIncentiveOwner,
+  readErc20PeggedIncentiveReward,
+  readErc20PeggedIncentiveTotalClaimed,
+  simulateErc20PeggedIncentiveClaim,
+  simulateErc20PeggedIncentiveClawback,
+  writeErc20PeggedIncentiveClaim,
+  writeErc20PeggedIncentiveClawback,
+} from '@boostxyz/evm';
+import { bytecode } from '@boostxyz/evm/artifacts/contracts/incentives/ERC20PeggedIncentive.sol/ERC20PeggedIncentive.json';
+import {
+  type Address,
+  type ContractEventName,
+  type Hex,
+  encodeAbiParameters,
+  zeroAddress,
+  zeroHash,
+} from 'viem';
+import { ERC20Incentive as ERC20IncentiveBases } from '../../dist/deployments.json';
+import type {
+  DeployableOptions,
+  GenericDeployableParams,
+} from '../Deployable/Deployable';
+import { DeployableTarget } from '../Deployable/DeployableTarget';
+import { type ClaimPayload, prepareClaimPayload } from '../claiming';
+import {
+  type GenericLog,
+  type ReadParams,
+  RegistryType,
+  type WriteParams,
+} from '../utils';
+
+export { erc20PeggedIncentiveAbi };
+
+/**
+ * The object representation of a `ERC20Incentive.InitPayload`
+ *
+ * @export
+ * @interface ERC20PeggedIncentivePayload
+ * @typedef {ERC20PeggedIncentivePayload}
+ */
+export interface ERC20PeggedIncentivePayload {
+  /**
+   * The address of the incentivized asset.
+   *
+   * @type {Address}
+   */
+  asset: Address;
+  /**
+   * The peg to normalize to.
+   *
+   * @type {Address}
+   */
+  peg: Address;
+  /**
+   * The amount of the asset to distribute.
+   *
+   * @type {bigint}
+   */
+  reward: bigint;
+  /**
+   * Total spend for the incentive.
+   *
+   * @type {bigint}
+   */
+  limit: bigint;
+  /**
+   * (Optional) The address of the entity that can managed the incentive.
+   *
+   * @type {Address}
+   * @optional
+   */
+  manager?: Address;
+}
+
+/**
+ * A generic `viem.Log` event with support for `ERC20Incentive` event types.
+ *
+ * @export
+ * @typedef {ERC20PeggedIncentiveLog}
+ * @template {ContractEventName<typeof erc20PeggedIncentiveAbi>} [event=ContractEventName<
+ *     typeof erc20PeggedIncentiveAbi
+ *   >]
+ */
+export type ERC20PeggedIncentiveLog<
+  event extends ContractEventName<
+    typeof erc20PeggedIncentiveAbi
+  > = ContractEventName<typeof erc20PeggedIncentiveAbi>,
+> = GenericLog<typeof erc20PeggedIncentiveAbi, event>;
+
+/**
+ * A simple ERC20 incentive implementation that allows claiming of tokens
+ *
+ * @export
+ * @class ERC20Incentive
+ * @typedef {ERC20Incentive}
+ * @extends {DeployableTarget<ERC20PeggedIncentivePayload>}
+ */
+export class ERC20PeggedIncentive extends DeployableTarget<
+  ERC20PeggedIncentivePayload,
+  typeof erc20PeggedIncentiveAbi
+> {
+  public override readonly abi = erc20PeggedIncentiveAbi;
+  /**
+   * @inheritdoc
+   *
+   * @public
+   * @static
+   * @type {Record<number, Address>}
+   */
+  public static override bases: Record<number, Address> = {
+    31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE,
+    ...(ERC20IncentiveBases as Record<number, Address>),
+  };
+  /**
+   * @inheritdoc
+   *
+   * @public
+   * @static
+   * @type {RegistryType}
+   */
+  public static override registryType: RegistryType = RegistryType.INCENTIVE;
+
+  /**
+   * The owner of the incentive
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>}
+   */
+  public async owner(params?: ReadParams) {
+    return await readErc20PeggedIncentiveOwner(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * Calculates the current reward based on the time since the last claim. The reward is calculated based on the time since the last claim, the available budget, and the reward parameters. It increases linearly over time in the absence of claims, with each hour adding `rewardBoost` to the current reward, up to the available budget. For example, if there is one claim in the first hour, then no claims for three hours, the claimable reward would be `initialReward - rewardDecay + (rewardBoost * 3)`
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>} - The current reward
+   */
+  public async currentReward(params?: ReadParams) {
+    return await readErc20PeggedIncentiveCurrentReward(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * The number of claims that have been made
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>}
+   */
+  public async claims(params?: ReadParams) {
+    return await readErc20PeggedIncentiveClaims(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * The total amount of rewards claimed
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>}
+   */
+  public async totalClaimed(params?: ReadParams) {
+    return await readErc20PeggedIncentiveTotalClaimed(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * A mapping of address to claim status
+   *
+   * @public
+   * @async
+   * @param {Address} address
+   * @param {?ReadParams} [params]
+   * @returns {Promise<boolean>}
+   */
+  public async claimed(address: Address, params?: ReadParams) {
+    return await readErc20PeggedIncentiveClaimed(this._config, {
+      address: this.assertValidAddress(),
+      args: [address],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * The address of the ERC20-like token
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>}
+   */
+  public async asset(params?: ReadParams) {
+    return await readErc20PeggedIncentiveAsset(this._config, {
+      address: this.assertValidAddress(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * The reward amount issued for each claim
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>}
+   */
+  public async reward(params?: ReadParams) {
+    return await readErc20PeggedIncentiveReward(this._config, {
+      address: this.assertValidAddress(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * The limit (max possible rewards payout in reward token)
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>}
+   */
+  public async limit(params?: ReadParams) {
+    return await readErc20PeggedIncentiveLimit(this._config, {
+      address: this.assertValidAddress(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * Claim the incentive
+   *
+   * @public
+   * @async
+   * @param {ClaimPayload} payload
+   * @param {?WriteParams} [params]
+   * @returns {Promise<boolean>} - Returns true if successfully claimed
+   */
+  protected async claim(payload: ClaimPayload, params?: WriteParams) {
+    return await this.awaitResult(this.claimRaw(payload, params));
+  }
+
+  /**
+   * Claim the incentive
+   *
+   * @public
+   * @async
+   * @param {ClaimPayload} payload
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} - Returns true if successfully claimed
+   */
+  protected async claimRaw(payload: ClaimPayload, params?: WriteParams) {
+    const { request, result } = await simulateErc20PeggedIncentiveClaim(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [prepareClaimPayload(payload)],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeErc20PeggedIncentiveClaim(this._config, request);
+    return { hash, result };
+  }
+
+  /**
+   * Clawback assets from the incentive
+   *
+   * @public
+   * @async
+   * @param {ClaimPayload} payload
+   * @param {?WriteParams} [params]
+   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
+   */
+  public async clawback(payload: ClaimPayload, params?: WriteParams) {
+    return await this.awaitResult(this.clawbackRaw(payload, params));
+  }
+
+  /**
+   * Clawback assets from the incentive
+   *
+   * @public
+   * @async
+   * @param {ClaimPayload} payload
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: boolean; }>} -  True if the assets were successfully clawbacked
+   */
+  public async clawbackRaw(payload: ClaimPayload, params?: WriteParams) {
+    const { request, result } = await simulateErc20PeggedIncentiveClawback(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [prepareClaimPayload(payload)],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeErc20PeggedIncentiveClawback(this._config, request);
+    return { hash, result };
+  }
+
+  /**
+   * Check if an incentive is claimable.
+   *
+   * @public
+   * @async
+   * @param {ClaimPayload} payload
+   * @param {?ReadParams} [params]
+   * @returns {Promise<boolean>} = True if the incentive is claimable based on the data payload
+   */
+  public async isClaimable(payload: ClaimPayload, params?: ReadParams) {
+    return await readErc20PeggedIncentiveIsClaimable(this._config, {
+      address: this.assertValidAddress(),
+      args: [payload.target, payload.data],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * read the peg token for the incentive.
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>} = The address of the token the reward is pegged to
+   */
+  public async getPeg(params?: ReadParams) {
+    return await readErc20PeggedIncentiveGetPeg(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * Get the maximum amount that can be claimed by this incentive. Useful when used in conjunction with `BoostCore.calculateProtocolFee`
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>} = Return a bigint representing that maximum amount that can be distributed by this incentive.
+   */
+  public async getTotalBudget(params?: ReadParams) {
+    return await this.limit(params);
+  }
+
+  /**
+   * Check if any claims remain by comparing the incentive's total claims against its limit. Does not take requesting user's elligibility into account.
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<boolean>} - True if total claims is less than limit
+   */
+  public async canBeClaimed(params?: ReadParams) {
+    return (await this.getRemainingClaimPotential(params)) > 0n;
+  }
+
+  /**
+   * Check how many claims remain by comparing the incentive's total claims against its limit. Does not take requesting user's elligibility into account.
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<bigint>} - True if total claims is less than limit
+   */
+  public async getRemainingClaimPotential(params?: ReadParams) {
+    const [claims, limit] = await Promise.all([
+      this.claims(params),
+      this.limit(params),
+    ]);
+    return limit - claims;
+  }
+
+  /**
+   * @inheritdoc
+   *
+   * @public
+   * @param {?ERC20PeggedIncentivePayload} [_payload]
+   * @param {?DeployableOptions} [_options]
+   * @returns {GenericDeployableParams}
+   */
+  public override buildParameters(
+    _payload?: ERC20PeggedIncentivePayload,
+    _options?: DeployableOptions,
+  ): GenericDeployableParams {
+    const [payload, options] = this.validateDeploymentConfig(
+      _payload,
+      _options,
+    );
+    return {
+      abi: erc20PeggedIncentiveAbi,
+      bytecode: bytecode as Hex,
+      args: [prepareERC20PeggedIncentivePayload(payload)],
+      ...this.optionallyAttachAccount(options.account),
+    };
+  }
+
+  /**
+   * Encodes an amount to clawback from the incentive
+   *
+   * @public
+   * @param {bigint} amount - How much of the asset to clawback
+   * @returns {Hex} - Returns an encoded uint256
+   */
+  public buildClawbackData(amount: bigint) {
+    return encodeAbiParameters([{ type: 'uint256' }], [amount]);
+  }
+
+  /**
+   * Builds the claim data for the ERC20Incentive.
+   *
+   * @public
+   * @returns {Hash} A `zeroHash`, as ERC20Incentive doesn't require specific claim data.
+   * @description This function returns `zeroHash` because ERC20Incentive doesn't use any specific claim data.
+   */
+  public buildClaimData() {
+    return zeroHash;
+  }
+}
+
+/**
+ * Given a {@link ERC20PeggedIncentivePayload}, properly encode a `ERC20Incentive.InitPayload` for use with {@link ERC20Incentive} initialization.
+ *
+ * @param {ERC20PeggedIncentivePayload} param0
+ * @param {Address} param0.asset - The address of the incentivized asset.
+ * @param {Address} param0.peg - The peg to normalize to.
+ * @param {bigint} param0.reward - The amount of the asset to distribute.
+ * @param {bigint} param0.limit - How many times can this incentive be claimed.
+ * @param {Address} [param0.manager=zeroAddress] - The entity that can manage the incentive.
+ * @returns {Hex}
+ */
+export function prepareERC20PeggedIncentivePayload({
+  asset,
+  peg,
+  reward,
+  limit,
+  manager = zeroAddress,
+}: ERC20PeggedIncentivePayload) {
+  return encodeAbiParameters(
+    [
+      { type: 'address', name: 'asset' },
+      { type: 'address', name: 'peg' },
+      { type: 'uint256', name: 'reward' },
+      { type: 'uint256', name: 'limit' },
+      { type: 'address', name: 'manager' },
+    ],
+    [asset, peg, reward, limit, manager],
+  );
+}

--- a/packages/sdk/src/Incentives/Incentive.ts
+++ b/packages/sdk/src/Incentives/Incentive.ts
@@ -3,6 +3,7 @@ import {
   AAllowListIncentive,
   ACGDAIncentive,
   AERC20Incentive,
+  AERC20PeggedIncentive,
   AERC20VariableCriteriaIncentive,
   AERC20VariableIncentive,
   // AERC20VariableCriteriaIncentive
@@ -16,6 +17,7 @@ import type { ReadParams } from '../utils';
 import { AllowListIncentive } from './AllowListIncentive';
 import { CGDAIncentive } from './CGDAIncentive';
 import { ERC20Incentive } from './ERC20Incentive';
+import { ERC20PeggedIncentive } from './ERC20PeggedIncentive';
 import { ERC20VariableCriteriaIncentive } from './ERC20VariableCriteriaIncentive';
 import { ERC20VariableIncentive } from './ERC20VariableIncentive';
 // import { ERC1155Incentive } from './ERC1155Incentive';
@@ -26,6 +28,7 @@ export {
   CGDAIncentive,
   // ERC1155Incentive,
   ERC20Incentive,
+  ERC20PeggedIncentive,
   PointsIncentive,
   ERC20VariableIncentive,
   ERC20VariableCriteriaIncentive,
@@ -42,6 +45,7 @@ export type Incentive =
   | CGDAIncentive
   | ERC20Incentive
   // | ERC1155Incentive
+  | ERC20PeggedIncentive
   | PointsIncentive
   | ERC20VariableIncentive
   | ERC20VariableCriteriaIncentive;
@@ -49,11 +53,12 @@ export type Incentive =
 /**
  * A map of Incentive component interfaces to their constructors.
  *
- * @type {{ "0xc5b24b8e": typeof PointsIncentive; "0x8c901437": typeof ERC20Incentive; "0x4414fbb4": typeof AllowListIncentive; "0xa39e44d9": typeof CGDAIncentive; "0xa8e4af1e": typeof ERC20VariableIncentive; "0x90318111": typeof ERC20VariableCriteriaIncentive }}
+ * @type {{ "0xc5b24b8e": typeof PointsIncentive; "0x8c901437": typeof ERC20Incentive; "0x4414fbb4": typeof ERC20PeggedIncentive; "0x56586338" typeof AllowListIncentive; "0xa39e44d9": typeof CGDAIncentive; "0xa8e4af1e": typeof ERC20VariableIncentive; "0x90318111": typeof ERC20VariableCriteriaIncentive }}
  */
 export const IncentiveByComponentInterface = {
   [APointsIncentive as Hex]: PointsIncentive,
   [AERC20Incentive as Hex]: ERC20Incentive,
+  [AERC20VariableIncentive as Hex]: ERC20VariableIncentive,
   [AAllowListIncentive]: AllowListIncentive,
   // [AERC1155Incentive as Hex]: ERC1155Incentive,
   [ACGDAIncentive as Hex]: CGDAIncentive,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -35,6 +35,7 @@ export * from './Deployable/DeployableTargetWithRBAC';
 export * from './Incentives/AllowListIncentive';
 export * from './Incentives/CGDAIncentive';
 export * from './Incentives/ERC20Incentive';
+export * from './Incentives/ERC20PeggedIncentive';
 export * from './Incentives/ERC20VariableIncentive';
 export * from './Incentives/ERC20VariableCriteriaIncentive';
 // export * from './Incentives/ERC1155Incentive';


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
This PR adds a new incentive type. It's almost like a mix of the variable incentive and the standard erc20 incentive. I stripped out raffle functionality.

Limit for this incentive is the _total spend_ similar to a variable incentive.

The claim amount will always be the signed amount so the signed amount should be the reward amount in the peg token converted into the reward token.

Reward amount should be denominated in peg token and then signed amount should be the spot price conversion between reward token and peg token such that the **signed amount in reward token** = **reward amount in pegged token**. This means in the signature endpoint we'll need to fetch the reward amount, get the spot price conversion between reward token and pegged token, convert reward amount in peg token to reward token, and sign the result.



💔 Thank you!
