### PR TITLE
[BOOST-5072] feat(evm): add fee module to core and pass value to validators

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -145,7 +145,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
         // Setup the Boost components
         boost.action = AAction(_makeTarget(type(AAction).interfaceId, payload_.action, true));
         boost.allowList = AAllowList(_makeTarget(type(AAllowList).interfaceId, payload_.allowList, true));
-        boost.incentives = _makeIncentives(payload_.incentives, payload_.budget, payload_.protocolFee);
+        boost.incentives = _makeIncentives(payload_.incentives, payload_.budget, boost.protocolFee);
         boost.validator = AValidator(
             payload_.validator.instance == address(0)
                 ? boost.action.supportsInterface(type(AValidator).interfaceId) ? address(boost.action) : address(0)
@@ -453,7 +453,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
     {
         // Decode the preflight data to extract the transfer details
         ABudget.Transfer memory request = abi.decode(preflight, (ABudget.Transfer));
-        uint64 totalFee = _protocolFee + protocolFee;
+        uint64 totalFee = _protocolFee;
 
         if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
             // Decode the fungible payload
@@ -524,7 +524,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
         uint256 incentiveId,
         address asset,
         uint256 totalProtocolFees,
-        uint256 additionalProtocolFee,
+        uint256 protocolFee_,
         ABudget.AssetType assetType,
         bytes memory extraData
     ) internal {
@@ -538,7 +538,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
             assetType,
             asset,
             totalProtocolFees,
-            protocolFee + additionalProtocolFee, // We store the current protocol fee in case it changes in the future
+            protocolFee_, // We store the current protocol fee in case it changes in the future
             tokenId
         );
 

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -31,17 +31,6 @@ contract BoostCore is Ownable, ReentrancyGuard {
     using LibZip for bytes;
     using SafeTransferLib for address;
 
-    struct InitPayload {
-        ABudget budget;
-        BoostLib.Target action;
-        BoostLib.Target validator;
-        BoostLib.Target allowList;
-        BoostLib.Target[] incentives;
-        uint64 protocolFee;
-        uint256 maxParticipants;
-        address owner;
-    }
-
     event BoostCreated(
         uint256 indexed boostId,
         address indexed owner,
@@ -128,7 +117,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
         nonReentrant
         returns (BoostLib.Boost memory)
     {
-        InitPayload memory payload_ = abi.decode(data_.cdDecompress(), (InitPayload));
+        BoostLib.CreateBoostPayload memory payload_ = abi.decode(data_.cdDecompress(), (BoostLib.CreateBoostPayload));
 
         // Validate the Budget
         _checkBudget(payload_.budget);

--- a/packages/evm/contracts/actions/ERC721MintAction.sol
+++ b/packages/evm/contracts/actions/ERC721MintAction.sol
@@ -53,6 +53,7 @@ contract ERC721MintAction is AOwnable, AERC721MintAction {
     /// @dev Example: `abi.encode(address(holder), abi.encode(uint256(tokenId)))`
     function validate(uint256, /*unused*/ uint256, /* unused */ address, /*unused*/ bytes calldata data_)
         external
+        payable
         virtual
         override
         returns (bool success)

--- a/packages/evm/contracts/shared/BoostLib.sol
+++ b/packages/evm/contracts/shared/BoostLib.sol
@@ -27,8 +27,19 @@ library BoostLib {
         address owner;
     }
 
+    struct CreateBoostPayload {
+        ABudget budget;
+        BoostLib.Target action;
+        BoostLib.Target validator;
+        BoostLib.Target allowList;
+        BoostLib.Target[] incentives;
+        uint64 protocolFee;
+        uint256 maxParticipants;
+        address owner;
+    }
     /// @notice A base struct for a contract and its initialization parameters
     /// @dev This is used to pass the base contract and its initialization parameters in an efficient manner
+
     struct Target {
         bool isBase;
         address instance;

--- a/packages/evm/contracts/shared/IProtocolFeeModule.sol
+++ b/packages/evm/contracts/shared/IProtocolFeeModule.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {ABudget} from "contracts/budgets/ABudget.sol";
+import {BoostLib} from "contracts/shared/BoostLib.sol";
+
+interface IProtocolFeeModule {
+    // NOTE: should we include this here and/or should we migrate it into BoostLib??
+    struct InitPayload {
+        ABudget budget;
+        BoostLib.Target action;
+        BoostLib.Target validator;
+        BoostLib.Target allowList;
+        BoostLib.Target[] incentives;
+        uint64 protocolFee;
+        uint256 maxParticipants;
+        address owner;
+    }
+
+    /// @notice Returns the protocol fee
+    /// @return The protocol fee as a uint256
+    function getProtocolFee(bytes calldata data_) external view returns (uint64);
+}

--- a/packages/evm/contracts/shared/IProtocolFeeModule.sol
+++ b/packages/evm/contracts/shared/IProtocolFeeModule.sol
@@ -5,19 +5,7 @@ import {ABudget} from "contracts/budgets/ABudget.sol";
 import {BoostLib} from "contracts/shared/BoostLib.sol";
 
 interface IProtocolFeeModule {
-    // NOTE: should we include this here and/or should we migrate it into BoostLib??
-    struct InitPayload {
-        ABudget budget;
-        BoostLib.Target action;
-        BoostLib.Target validator;
-        BoostLib.Target allowList;
-        BoostLib.Target[] incentives;
-        uint64 protocolFee;
-        uint256 maxParticipants;
-        address owner;
-    }
-
     /// @notice Returns the protocol fee
-    /// @return The protocol fee as a uint256
+    /// @return The protocol fee as a uint64
     function getProtocolFee(bytes calldata data_) external view returns (uint64);
 }

--- a/packages/evm/contracts/shared/Mocks.sol
+++ b/packages/evm/contracts/shared/Mocks.sol
@@ -6,6 +6,7 @@ import {ERC20} from "@solady/tokens/ERC20.sol";
 import {ERC721} from "@solady/tokens/ERC721.sol";
 import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import {IAuth} from "contracts/auth/IAuth.sol";
+import {IProtocolFeeModule} from "contracts/shared/IProtocolFeeModule.sol";
 
 /**
  * 🚨 WARNING: The mocks in this file are for testing purposes only. DO NOT use
@@ -91,5 +92,29 @@ contract MockAuth is IAuth {
     /// @dev This function overrides the isAuthorized function in the IAuth interface.
     function isAuthorized(address addr) external view override returns (bool) {
         return _isAuthorized[addr];
+    }
+}
+
+/// @title MockProtocolFeeModule
+/// @notice A mock implementation of the IProtocolFeeModule interface (FOR TESTING PURPOSES ONLY)
+contract MockProtocolFeeModule is IProtocolFeeModule {
+    uint64 private protocolFee;
+
+    /// @notice Initializes the contract with a protocol fee.
+    /// @param _protocolFee The protocol fee to set.
+    constructor(uint64 _protocolFee) {
+        protocolFee = _protocolFee;
+    }
+
+    /// @notice Returns the protocol fee.
+    /// @return uint64 The protocol fee.
+    function getProtocolFee(bytes calldata) external view override returns (uint64) {
+        return protocolFee;
+    }
+
+    /// @notice Sets the protocol fee.
+    /// @param _protocolFee The new protocol fee.
+    function setProtocolFee(uint64 _protocolFee) external {
+        protocolFee = _protocolFee;
     }
 }

--- a/packages/evm/contracts/shared/Mocks.sol
+++ b/packages/evm/contracts/shared/Mocks.sol
@@ -118,3 +118,36 @@ contract MockProtocolFeeModule is IProtocolFeeModule {
         protocolFee = _protocolFee;
     }
 }
+
+/// @title MockProtocolFeeModule
+/// @notice A mock implementation of the IProtocolFeeModule interface (FOR TESTING PURPOSES ONLY)
+contract MockProtocolFeeModuleBadReturn {
+    uint256 private protocolFee;
+
+    /// @notice Initializes the contract with a protocol fee.
+    /// @param _protocolFee The protocol fee to set.
+    constructor(uint256 _protocolFee) {
+        protocolFee = _protocolFee;
+    }
+
+    /// @notice Returns the protocol fee.
+    /// @return uint64 The protocol fee.
+    function getProtocolFee(bytes calldata) external view returns (uint256) {
+        return protocolFee;
+    }
+
+    /// @notice Sets the protocol fee.
+    /// @param _protocolFee The new protocol fee.
+    function setProtocolFee(uint256 _protocolFee) external {
+        protocolFee = _protocolFee;
+    }
+}
+
+/// @title MockProtocolFeeModule
+/// @notice A mock implementation of the IProtocolFeeModule interface (FOR TESTING PURPOSES ONLY)
+contract MockProtocolFeeModuleNoReturn {
+    uint256 private protocolFee;
+
+    /// @notice Returns the protocol fee.
+    function getProtocolFee(bytes calldata) external view {}
+}

--- a/packages/evm/contracts/validators/AValidator.sol
+++ b/packages/evm/contracts/validators/AValidator.sol
@@ -16,6 +16,7 @@ abstract contract AValidator is ACloneable {
     /// @dev The decompressed payload contains freeform bytes that are entirely implementation-specific
     function validate(uint256 boostId, uint256 incentiveId, address claimant, bytes calldata data)
         external
+        payable
         virtual
         returns (bool);
 

--- a/packages/evm/contracts/validators/LimitedSignerValidator.sol
+++ b/packages/evm/contracts/validators/LimitedSignerValidator.sol
@@ -39,6 +39,7 @@ contract LimitedSignerValidator is ALimitedSignerValidator, SignerValidator {
     /// @inheritdoc AValidator
     function validate(uint256 boostId, uint256 incentiveId, address claimant, bytes calldata claimData)
         public
+        payable
         override(AValidator, SignerValidator)
         returns (bool)
     {

--- a/packages/evm/contracts/validators/SignerValidator.sol
+++ b/packages/evm/contracts/validators/SignerValidator.sol
@@ -53,6 +53,7 @@ contract SignerValidator is ASignerValidator, Ownable, EIP712 {
     /// @inheritdoc AValidator
     function validate(uint256 boostId, uint256 incentiveId, address claimant, bytes calldata claimData)
         public
+        payable
         virtual
         override
         returns (bool)

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -35,7 +35,11 @@ import {BoostRegistry} from "contracts/BoostRegistry.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
 import {BoostLib} from "contracts/shared/BoostLib.sol";
 import {ACloneable} from "contracts/shared/ACloneable.sol";
-import {MockProtocolFeeModule, MockProtocolFeeModuleNoReturn, MockProtocolFeeModuleBadReturn} from "contracts/shared/Mocks.sol";
+import {
+    MockProtocolFeeModule,
+    MockProtocolFeeModuleNoReturn,
+    MockProtocolFeeModuleBadReturn
+} from "contracts/shared/Mocks.sol";
 
 contract BoostCoreTest is Test {
     using LibClone for address;
@@ -326,7 +330,7 @@ contract BoostCoreTest is Test {
         );
 
         vm.expectRevert();
-        
+
         // Call createBoost
         boostCore.createBoost(createCalldata);
     }
@@ -364,7 +368,6 @@ contract BoostCoreTest is Test {
         // Call createBoost
         boostCore.createBoost(createCalldata);
     }
-
 
     function testCreateBoost_AfterSetProtocolFeeModule() public {
         // Create a mock protocol fee module with a specific fee
@@ -407,7 +410,6 @@ contract BoostCoreTest is Test {
         // Verify that the boost's protocolFee is correct
         assertEq(boost.protocolFee, expectedProtocolFee, "Protocol fee should be sum of module fee and payload fee");
     }
-
 
     //////////////////////////////////
     // BoostCore.setCreateBoostAuth //

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -58,7 +58,7 @@ contract BoostCoreTest is Test {
 
     bytes validCreateCalldata = LibZip.cdCompress(
         abi.encode(
-            BoostCore.InitPayload({
+            BoostLib.CreateBoostPayload({
                 budget: budget,
                 action: action,
                 validator: BoostLib.Target({isBase: true, instance: address(0), parameters: ""}),
@@ -132,7 +132,7 @@ contract BoostCoreTest is Test {
     function testCreateBoost_NoValidator() public {
         bytes memory invalidCreateCalldata = LibZip.cdCompress(
             abi.encode(
-                BoostCore.InitPayload({
+                BoostLib.CreateBoostPayload({
                     budget: budget,
                     action: contractAction,
                     validator: BoostLib.Target({isBase: true, instance: address(0), parameters: ""}),
@@ -250,7 +250,7 @@ contract BoostCoreTest is Test {
         // Try to create a Boost with an address that doesn't support the ABudget interface (should fail)
         bytes memory calldata_ = LibZip.cdCompress(
             abi.encode(
-                BoostCore.InitPayload(
+                BoostLib.CreateBoostPayload(
                     ABudget(payable(action.instance)),
                     action,
                     BoostLib.Target({isBase: true, instance: address(0), parameters: ""}),
@@ -277,7 +277,7 @@ contract BoostCoreTest is Test {
         // Try to create a Boost with an invalid AAction (should fail)
         bytes memory invalidActionCalldata = LibZip.cdCompress(
             abi.encode(
-                BoostCore.InitPayload(
+                BoostLib.CreateBoostPayload(
                     budget,
                     BoostLib.Target({isBase: true, instance: address(0), parameters: ""}),
                     action,
@@ -312,7 +312,7 @@ contract BoostCoreTest is Test {
 
         bytes memory createCalldata = LibZip.cdCompress(
             abi.encode(
-                BoostCore.InitPayload({
+                BoostLib.CreateBoostPayload({
                     budget: budget,
                     action: action,
                     validator: BoostLib.Target({isBase: true, instance: address(0), parameters: ""}),

--- a/packages/evm/test/e2e/EndToEndBasic.t.sol
+++ b/packages/evm/test/e2e/EndToEndBasic.t.sol
@@ -309,7 +309,7 @@ contract EndToEndBasic is Test {
         return core.createBoost(
             LibZip.cdCompress(
                 abi.encode(
-                    BoostCore.InitPayload(
+                    BoostLib.CreateBoostPayload(
                         // "... with my budget"
                         budget,
                         BoostLib.Target({

--- a/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
+++ b/packages/evm/test/e2e/EndToEndSignerValidator.t.sol
@@ -268,7 +268,7 @@ contract EndToEndSignerValidator is Test, OwnableRoles {
         return core.createBoost(
             LibZip.cdCompress(
                 abi.encode(
-                    BoostCore.InitPayload(
+                    BoostLib.CreateBoostPayload(
                         // "... with my budget"
                         budget,
                         BoostLib.Target({

--- a/packages/evm/test/shared/Mocks.t.sol
+++ b/packages/evm/test/shared/Mocks.t.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.24;
 
 import {Test, console} from "lib/forge-std/src/Test.sol";
-import {MockERC20, MockERC721} from "contracts/shared/Mocks.sol";
+import {MockERC20, MockERC721, MockAuth, MockProtocolFeeModule} from "contracts/shared/Mocks.sol";
 import {MockAuth} from "contracts/shared/Mocks.sol"; // Add this import at the top with the others
 
 contract MocksTest is Test {
     MockERC20 mockERC20;
     MockERC721 mockERC721;
     MockAuth mockAuth;
+    MockProtocolFeeModule mockProtocolFeeModule;
     address[] mockAddresses;
     address authorizedBoostCreator = makeAddr("authorizedBoostCreator");
 
@@ -17,6 +18,7 @@ contract MocksTest is Test {
         mockERC721 = new MockERC721();
         mockAddresses.push(authorizedBoostCreator);
         mockAuth = new MockAuth(mockAddresses);
+        mockProtocolFeeModule = new MockProtocolFeeModule(100); // Example protocol fee
     }
 
     ///////////////
@@ -104,5 +106,17 @@ contract MocksTest is Test {
 
     function testMockAuthIsNotAuthorized() public {
         assertFalse(mockAuth.isAuthorized(address(this)));
+    }
+
+    /////////////////////////////
+    // MockProtocolFeeModule //
+    /////////////////////////////
+    function testMockProtocolFeeModule_getProtocolFee() public {
+        assertEq(mockProtocolFeeModule.getProtocolFee(""), 100);
+    }
+
+    function testMockProtocolFeeModule_setProtocolFee() public {
+        mockProtocolFeeModule.setProtocolFee(200);
+        assertEq(mockProtocolFeeModule.getProtocolFee(""), 200);
     }
 }


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
This makes two major changes:
- Adds protocol fee module hooks into core
- Makes validators payable so that we can pass through native tokens for fees as needed.

This is still in draft as I need to pad out test coverage which means we need a mock testing version of this module. I'm going to add that ASAP but this should be all of the actual contract changes. The way I set it requires minimal changes to the existing tests but I'm open to the idea of passing the module through on construction.

Also worth looking at the note in the interface to weigh in on approach there/where the struct should live.
