### PR TITLE
[ADHOC] Build Claim Data for ERC20PeggedIncentive

### DIFF
--- a/.changeset/slow-apricots-heal.md
+++ b/.changeset/slow-apricots-heal.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+generate build claim data for ERC20PeggedIncentive

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -468,11 +468,15 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    * Builds the claim data for the ERC20PeggedIncentive.
    *
    * @public
-   * @returns {Hash} A `zeroHash`, as ERC20PeggedIncentive doesn't require specific claim data.
-   * @description This function returns `zeroHash` because ERC20PeggedIncentive doesn't use any specific claim data.
+   * @param {bigint} rewardAmount
+   * @returns {Hash} Returns the encoded claim data
+   * @description This function returns the encoded claim data for the ERC20PeggedIncentive.
    */
-  public buildClaimData() {
-    return zeroHash;
+  public buildClaimData(rewardAmount: bigint) {
+    return encodeAbiParameters(
+      [{ type: 'uint256', name: 'rewardAmount' }],
+      [rewardAmount],
+    );
   }
 }
 


### PR DESCRIPTION
### Description
Returns abi encoded value for ERC20PeggedIncentive instead of the zeroHash
