### PR TITLE
[BOOST-5104] fix issue with protocol fee transfer

### DIFF
--- a/.changeset/five-numbers-hide.md
+++ b/.changeset/five-numbers-hide.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/evm": minor
+---
+
+fix protocol fee transfer on claim

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -555,10 +555,11 @@ contract BoostCore is Ownable, ReentrancyGuard {
     }
 
     // Helper function to get the balance of the asset depending on its type
-    function _getAssetBalance(
-        IncentiveDisbursalInfo storage incentive,
-        AIncentive incentiveContract
-    ) internal view returns (uint256) {
+    function _getAssetBalance(IncentiveDisbursalInfo storage incentive, AIncentive incentiveContract)
+        internal
+        view
+        returns (uint256)
+    {
         if (incentive.assetType == ABudget.AssetType.ERC20 || incentive.assetType == ABudget.AssetType.ETH) {
             return IERC20(incentive.asset).balanceOf(address(incentiveContract));
         } else if (incentive.assetType == ABudget.AssetType.ERC1155) {


### PR DESCRIPTION
### Description

There is an issue with the way we were detecting the initial and final balance used to determine the protocol fee amount. We were checking the boostCore balance in `_getAssetBalance` instead of the balance of the incentive. This caused the protocolFeeAmount to always be zero, and no protocol fees are ever sent to the fee recipient.

The fix here is to check the incentive balance for changes instead of boostCore.


