### PR TITLE
[ADHOC] test(evm): add fuzz testing for additional fees

### DIFF
--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -338,7 +338,6 @@ contract BoostCoreTest is Test {
 
     function testCreateBoost_AfterSetProtocolFeeModule_NoReturn() public {
         // Create a mock protocol fee module with a specific fee
-        uint64 moduleFee = 200; // 2%
         MockProtocolFeeModuleNoReturn mockModule = new MockProtocolFeeModuleNoReturn();
 
         // Set the protocol fee module
@@ -424,9 +423,6 @@ contract BoostCoreTest is Test {
         // Create the boost
         boostCore.createBoost(validCreateCalldata);
 
-        // Fetch the newly created boost
-        BoostLib.Boost memory boost = boostCore.getBoost(0);
-
         // Verify that no protocol fee module asset was applied and that the incentive's asset is the original
         bytes32 key = keccak256(abi.encodePacked(uint256(0), uint256(0)));
         BoostCore.IncentiveDisbursalInfo memory info = boostCore.getIncentiveFeesInfo(key);
@@ -452,9 +448,6 @@ contract BoostCoreTest is Test {
 
         // Create a Boost
         boostCore.createBoost(validCreateCalldata);
-
-        // Fetch the newly created boost
-        BoostLib.Boost memory boost = boostCore.getBoost(0);
 
         // Verify that the protocol asset is correctly applied to the incentive
         bytes32 key = keccak256(abi.encodePacked(uint256(0), uint256(0)));


### PR DESCRIPTION
Just wanted to ensure that fee calculations behave as expected when
additional fees are added to boost.

This doesn't increase the significantly long time it takes this fuzz
test to run. It's just another param that gets fuzzed.
