### PR TITLE
[ADHOC] chore: add sdk/cache to ignored paths in biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,7 @@
       "packages/evm/out",
       "packages/evm/cache",
       "packages/evm/cache_forge",
+      "packages/sdk/cache",
       "dist",
       ".next",
       ".turbo"


### PR DESCRIPTION
### Description
- add sdk/cache to ignored files in biome config. we were seeing many errors appear from the cache as shown in the image below. 

![CleanShot 2024-12-15 at 21 16 27@2x](https://github.com/user-attachments/assets/08a6aeae-c83e-4451-874c-6322cc73bd3c)
