### PR TITLE
[ADHOC] fix(evm): incentive clawback perm fix

### DIFF
--- a/.changeset/strange-parents-lay.md
+++ b/.changeset/strange-parents-lay.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+standardize clawback logic

--- a/packages/evm/contracts/incentives/CGDAIncentive.sol
+++ b/packages/evm/contracts/incentives/CGDAIncentive.sol
@@ -32,6 +32,7 @@ contract CGDAIncentive is RBAC, ACGDAIncentive {
         uint256 rewardDecay;
         uint256 rewardBoost;
         uint256 totalBudget;
+        address manager;
     }
 
     /// @inheritdoc AIncentive
@@ -71,7 +72,7 @@ contract CGDAIncentive is RBAC, ACGDAIncentive {
 
         totalBudget = init_.totalBudget;
         _initializeOwner(msg.sender);
-        _setRoles(msg.sender, MANAGER_ROLE);
+        _setRoles(init_.manager, MANAGER_ROLE);
         emit CGDAIncentiveInitialized(
             init_.asset, init_.initialReward, init_.rewardDecay, init_.rewardBoost, init_.totalBudget
         );
@@ -120,7 +121,7 @@ contract CGDAIncentive is RBAC, ACGDAIncentive {
         external
         virtual
         override
-        onlyRoles(MANAGER_ROLE)
+        onlyOwnerOrRoles(MANAGER_ROLE)
         returns (uint256, address)
     {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));

--- a/packages/evm/contracts/incentives/ERC1155Incentive.sol
+++ b/packages/evm/contracts/incentives/ERC1155Incentive.sol
@@ -28,6 +28,7 @@ contract ERC1155Incentive is RBAC, AERC1155Incentive {
         uint256 tokenId;
         uint256 limit;
         bytes extraData;
+        address manager;
     }
 
     struct ERC1155ClaimPayload {
@@ -69,7 +70,7 @@ contract ERC1155Incentive is RBAC, AERC1155Incentive {
         extraData = init_.extraData;
 
         _initializeOwner(msg.sender);
-        _setRoles(msg.sender, MANAGER_ROLE);
+        _setRoles(init_.manager, MANAGER_ROLE);
         emit ERC1155IncentiveInitialized(asset, strategy, tokenId, limit);
     }
 
@@ -117,7 +118,12 @@ contract ERC1155Incentive is RBAC, AERC1155Incentive {
     }
 
     /// @inheritdoc AIncentive
-    function clawback(bytes calldata data_) external override onlyRoles(MANAGER_ROLE) returns (uint256, address) {
+    function clawback(bytes calldata data_)
+        external
+        override
+        onlyOwnerOrRoles(MANAGER_ROLE)
+        returns (uint256, address)
+    {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 

--- a/packages/evm/contracts/incentives/ERC20Incentive.sol
+++ b/packages/evm/contracts/incentives/ERC20Incentive.sol
@@ -111,7 +111,12 @@ contract ERC20Incentive is RBAC, AERC20Incentive {
     }
 
     /// @inheritdoc AIncentive
-    function clawback(bytes calldata data_) external override onlyOwner returns (uint256, address) {
+    function clawback(bytes calldata data_)
+        external
+        override
+        onlyOwnerOrRoles(MANAGER_ROLE)
+        returns (uint256, address)
+    {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 

--- a/packages/evm/contracts/incentives/ERC20PeggedIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20PeggedIncentive.sol
@@ -108,7 +108,12 @@ contract ERC20PeggedIncentive is RBAC, AERC20PeggedIncentive {
     }
 
     /// @inheritdoc AIncentive
-    function clawback(bytes calldata data_) external override onlyRoles(MANAGER_ROLE) returns (uint256, address) {
+    function clawback(bytes calldata data_)
+        external
+        override
+        onlyOwnerOrRoles(MANAGER_ROLE)
+        returns (uint256, address)
+    {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 

--- a/packages/evm/contracts/incentives/ERC20PeggedVariableCriteriaIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20PeggedVariableCriteriaIncentive.sol
@@ -137,7 +137,12 @@ contract ERC20PeggedVariableCriteriaIncentive is RBAC, AERC20PeggedVariableCrite
     }
 
     /// @inheritdoc AIncentive
-    function clawback(bytes calldata data_) external override onlyRoles(MANAGER_ROLE) returns (uint256, address) {
+    function clawback(bytes calldata data_)
+        external
+        override
+        onlyOwnerOrRoles(MANAGER_ROLE)
+        returns (uint256, address)
+    {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 

--- a/packages/evm/contracts/incentives/ERC20VariableIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20VariableIncentive.sol
@@ -25,6 +25,7 @@ contract ERC20VariableIncentive is AERC20VariableIncentive, RBAC {
         address asset;
         uint256 reward;
         uint256 limit;
+        address manager;
     }
 
     /// @inheritdoc AIncentive
@@ -64,7 +65,8 @@ contract ERC20VariableIncentive is AERC20VariableIncentive, RBAC {
         totalClaimed = 0;
 
         _initializeOwner(msg.sender);
-        _setRoles(msg.sender, MANAGER_ROLE);
+        address manager_ = init_.manager;
+        _setRoles(manager_, MANAGER_ROLE);
         emit ERC20VariableIncentiveInitialized(asset_, reward_, limit_);
     }
 
@@ -108,7 +110,12 @@ contract ERC20VariableIncentive is AERC20VariableIncentive, RBAC {
     }
 
     /// @inheritdoc AIncentive
-    function clawback(bytes calldata data_) external override onlyRoles(MANAGER_ROLE) returns (uint256, address) {
+    function clawback(bytes calldata data_)
+        external
+        override
+        onlyOwnerOrRoles(MANAGER_ROLE)
+        returns (uint256, address)
+    {
         ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -991,7 +991,7 @@ contract BoostCoreTest is Test {
                         strategy: AERC20Incentive.Strategy.POOL,
                         reward: rewardAmount,
                         limit: limit,
-                        manager: address(this)
+                        manager: address(boostCore)
                     })
                 )
             });

--- a/packages/evm/test/e2e/EndToEndBasic.t.sol
+++ b/packages/evm/test/e2e/EndToEndBasic.t.sol
@@ -303,7 +303,7 @@ contract EndToEndBasic is Test {
                 )
             ),
             // "... of '100 ERC20' with a max of 5 participants"
-            parameters: abi.encode(erc20, AERC20Incentive.Strategy.POOL, 100 ether, 5, address(budget))
+            parameters: abi.encode(erc20, AERC20Incentive.Strategy.POOL, 100 ether, 5, address(core))
         });
 
         return core.createBoost(

--- a/packages/evm/test/incentives/CGDAIncentive.t.sol
+++ b/packages/evm/test/incentives/CGDAIncentive.t.sol
@@ -31,7 +31,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(this)
                 })
             )
         );
@@ -51,7 +52,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(this)
                 })
             )
         );
@@ -82,7 +84,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(this)
                 })
             )
         );
@@ -100,7 +103,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 0, // Invalid initialReward
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(this)
                 })
             )
         );
@@ -118,7 +122,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 11 ether, // initialReward greater than totalBudget
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(this)
                 })
             )
         );
@@ -293,7 +298,8 @@ contract CGDAIncentiveTest is Test {
                     initialReward: 1 ether,
                     rewardDecay: 0.05 ether,
                     rewardBoost: 0.1 ether,
-                    totalBudget: 10 ether
+                    totalBudget: 10 ether,
+                    manager: address(this)
                 })
             )
         );

--- a/packages/evm/test/incentives/ERC1155Incentive.t.sol
+++ b/packages/evm/test/incentives/ERC1155Incentive.t.sol
@@ -265,7 +265,8 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
                 strategy: strategy,
                 tokenId: tokenId,
                 limit: limit,
-                extraData: ""
+                extraData: "",
+                manager: address(0)
             })
         );
     }

--- a/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
@@ -129,7 +129,14 @@ contract ERC20VariableIncentiveTest is Test {
 
     function testPreflight() public view {
         bytes memory preflightPayload = incentive.preflight(
-            abi.encode(ERC20VariableIncentive.InitPayload({asset: address(mockAsset), reward: 1 ether, limit: 5 ether}))
+            abi.encode(
+                ERC20VariableIncentive.InitPayload({
+                    asset: address(mockAsset),
+                    reward: 1 ether,
+                    limit: 5 ether,
+                    manager: address(this)
+                })
+            )
         );
 
         ABudget.Transfer memory transfer = abi.decode(preflightPayload, (ABudget.Transfer));
@@ -204,7 +211,9 @@ contract ERC20VariableIncentiveTest is Test {
     }
 
     function _initPayload(address asset, uint256 reward, uint256 limit) internal view returns (bytes memory) {
-        return abi.encode(ERC20VariableIncentive.InitPayload({asset: asset, reward: reward, limit: limit}));
+        return abi.encode(
+            ERC20VariableIncentive.InitPayload({asset: asset, reward: reward, limit: limit, manager: address(this)})
+        );
     }
 
     function _makeFungibleTransfer(ABudget.AssetType assetType, address asset, address target, uint256 value)

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -511,6 +511,7 @@ export function prepareCGDAIncentivePayload({
   rewardDecay,
   rewardBoost,
   totalBudget,
+  manager,
 }: CGDAIncentivePayload) {
   return encodeAbiParameters(
     [
@@ -519,7 +520,8 @@ export function prepareCGDAIncentivePayload({
       { type: 'uint256', name: 'rewardDecay' },
       { type: 'uint256', name: 'rewardBoost' },
       { type: 'uint256', name: 'totalBudget' },
+      { type: 'address', name: 'manager' },
     ],
-    [asset, initialReward, rewardDecay, rewardBoost, totalBudget],
+    [asset, initialReward, rewardDecay, rewardBoost, totalBudget, manager],
   );
 }

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.test.ts
@@ -294,4 +294,22 @@ describe("ERC20VariableCriteriaIncentive", () => {
       "0x0000000000000000000000000000000000000000000000000000000000000001",
     );
   });
+
+  test("can clawback via a budget", async () => {
+    // rebase this
+    const boost = await freshBoost(fixtures, {
+      budget: budgets.budget,
+      incentives: [erc20Incentive],
+    });
+    const [amount, address] = await budgets.budget.clawbackFromTarget(
+      fixtures.core.assertValidAddress(),
+      erc20Incentive.buildClawbackData(1n),
+      boost.id,
+      0,
+    );
+    expect(amount).toBe(1n);
+    expect(isAddressEqual(address, budgets.erc20.assertValidAddress())).toBe(
+      true,
+    );
+  });
 });

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -475,13 +475,15 @@ export function prepareERC20VariableIncentivePayload({
   asset,
   reward,
   limit,
+  manager,
 }: ERC20VariableIncentivePayload) {
   return encodeAbiParameters(
     [
       { type: 'address', name: 'asset' },
       { type: 'uint256', name: 'reward' },
       { type: 'uint256', name: 'limit' },
+      { type: 'address', name: 'manager' },
     ],
-    [asset, reward, limit],
+    [asset, reward, limit, manager],
   );
 }


### PR DESCRIPTION
We had a bunch of different logic for authing clawback on incentives.
This standardizes it to allow for the optional designation of a manager
outside of BoostCore, which always is configured as the owner via
the boost creation flow.
