### PR TITLE
[ADHOC] chore(ci): make danger re-run on PR edits

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -1,6 +1,11 @@
 name: "🚧 Danger"
 on:
   pull_request:
+    types: 
+      - opened
+      - reopened
+      - synchronize # captures and git pushes with changes
+      - edited  # This captures title and description changes
 jobs:
   danger:
     runs-on: ubuntu-latest

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -27,7 +27,10 @@ function rules() {
       );
     } else {
       // Remind people to add some details to the description, 200 accounts for roughly a sentence more than the standard template headers.
-      if (pr.body.includes('Thank you!') && pr.body.length < 200) {
+      if (
+        !pr.body ||
+        (pr.body.includes('Thank you!') && pr.body.length < 200)
+      ) {
         fail('Please add some non-placeholder details to the PR description.');
       } else if (pr.body.length < 80) {
         // if not using the template


### PR DESCRIPTION
I can modify the PR title and description and danger will re-run. This still also includes all the default `on: pull_request:` events as well.