### PR TITLE
[ADHOC] fix(sdk): auto-add boostcore as ManagedBudget manager

### DIFF
--- a/.changeset/few-pugs-behave.md
+++ b/.changeset/few-pugs-behave.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+auto-add boostcore as a manager in ManagedBudget

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -1281,6 +1281,13 @@ export class BoostCore extends Deployable<
    * @returns {ManagedBudget}
    */
   ManagedBudget(options: DeployablePayloadOrAddress<ManagedBudgetPayload>) {
+    if (
+      typeof options !== 'string' &&
+      !options.authorized.includes(this.assertValidAddress())
+    ) {
+      options.authorized = [this.assertValidAddress(), ...options.authorized];
+      options.roles = [Roles.MANAGER, ...options.roles];
+    }
     return new ManagedBudget(
       { config: this._config, account: this._account },
       options,
@@ -1301,7 +1308,10 @@ export class BoostCore extends Deployable<
   ManagedBudgetWithFees(
     options: DeployablePayloadOrAddress<ManagedBudgetWithFeesPayload>,
   ) {
-    if (typeof options !== 'string') {
+    if (
+      typeof options !== 'string' &&
+      !options.authorized.includes(this.assertValidAddress())
+    ) {
       options.authorized = [this.assertValidAddress(), ...options.authorized];
       options.roles = [Roles.MANAGER, ...options.roles];
     }

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": [".env", "src"],
+      "inputs": [".env", "src", "contracts"],
       "outputs": [
         "dist/**",
         "artifacts/**",


### PR DESCRIPTION
Deploying a budget from `core` should auto-add that core instance as a
manager, or the user will get an error if they don't add it themselves.
This might be addressed in boostxyz/boost, but it's probably better if
this affordance lives in the sdk.
