### PR TITLE
[BOOST-5131] feat: tuple support for eventaction

### DIFF
--- a/.changeset/itchy-news-exercise.md
+++ b/.changeset/itchy-news-exercise.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+[BOOST-5131] feat: tuple support for eventaction

--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -33,15 +33,16 @@ abstract contract AEventAction is AAction {
         UINT,
         ADDRESS,
         BYTES,
-        STRING
+        STRING,
+        TUPLE
     }
 
     // Define Structs
     struct Criteria {
         FilterType filterType;
         PrimitiveType fieldType;
-        // the parameter index in the event or function
-        uint8 fieldIndex;
+        // the parameter index in the event or function - keeping this size they should still pack to a single storage and the field will still be a number vs bigint
+        uint32 fieldIndex;
         // data fields in case we need more complex filtering; used with regex filters
         bytes filterData;
     }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,3 +5,13 @@ Typescript devkit for interacting with the Boost V2 Protocol
 [![Documentation](https://img.shields.io/badge/documentation-typedoc-blue)](boost-protocol.vercel.app)
 
 ## Visit [docs.boost.xyz](https://docs.boost.xyz) for docs, guides, API and more!
+
+
+## Event Actions
+
+### Tuple Handling
+When a field is declared as TUPLE in the `PrimitiveType` of an `EventAction`, we unpack its bit-packed fieldIndex to drill down through each nested level of the tuple. Each sub-index occupies 6 bits (values 0–63), and a sub-index of 63 is treated as a terminator—signaling the end of further drilling. Once we locate the leaf in the nested structure, the code infers the final (non-tuple) PrimitiveType by reading the ABI definition (address, uint256, string, etc.) at that leaf node.
+
+1. We can store up to 5 sub-indexes (each 6 bits) in one fieldIndex.
+1. As we parse a TUPLE, we read those sub-indexes one by one, traversing each nested tuple parameter in the ABI.
+1. At the final, non-tuple component, we derive the actual PrimitiveType (e.g., ADDRESS, UINT, BYTES, or STRING) by inspecting that component’s type in the ABI definition.

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1244,7 +1244,7 @@ describe("Tuple & bitpacked fieldIndex support", () => {
     test("throws if an index exceeds the max field index (63)", () => {
       // 64 is out of range
       expect(() => packFieldIndexes([64])).toThrowError(
-        /exceeds the maximum allowed value of 63 (terminator)/,
+        "Index 64 exceeds the maximum allowed value (63).",
       );
     });
 
@@ -1376,7 +1376,7 @@ describe("Tuple & bitpacked fieldIndex support", () => {
       );      
       expect(() =>
         action.parseFieldFromAbi(allArgs, tupleIndex, abiInputs, PrimitiveType.TUPLE),
-      ).toThrowError(/out of range for param.components/);
+      ).toThrowError("Failed to decode tuple: 9");
     });
   });
 });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -36,7 +36,8 @@ import {
   Criteria,
   anyActionParameter,
   transactionSenderClaimant,
-  packFieldIndexes, unpackFieldIndexes
+  packFieldIndexes,
+  unpackFieldIndexes
 } from "./EventAction";
 import { allKnownSignatures } from "@boostxyz/test/allKnownSignatures";
 import { getTransactionReceipt } from "@wagmi/core";

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -11,6 +11,7 @@ import { match } from 'ts-pattern';
 import {
   type AbiEvent,
   type AbiFunction,
+  type AbiParameter,
   type Address,
   type GetLogsReturnType,
   type GetTransactionParameters,
@@ -88,6 +89,7 @@ export enum PrimitiveType {
   ADDRESS = 1,
   BYTES = 2,
   STRING = 3,
+  // Note: TUPLE remains in the enum but is no longer handled directly by `validateFieldAgainstCriteria`.
   TUPLE = 4,
 }
 
@@ -113,6 +115,9 @@ export interface Criteria {
   fieldType: PrimitiveType;
   /**
    * The index in the logs argument array where the field is located.
+   *
+   * If `fieldType` is TUPLE, this value is **bitpacked** with up to 5 sub-indexes,
+   * with the maximum 6-bit value used as a "terminator" to indicate no further indexes.
    *
    * @type {number}
    */
@@ -704,7 +709,7 @@ export class EventAction extends DeployableTarget<
 
       // Use the provided logs, no need to fetch receipt
       if ('logs' in params) {
-        return this.isActionEventValid(actionStep, params.logs);
+        return this.isActionEventValid(actionStep, params.logs, event);
       }
 
       const receipt = await getTransactionReceipt(this._config, {
@@ -735,7 +740,7 @@ export class EventAction extends DeployableTarget<
           return { ...log, eventName, args };
         });
 
-      return this.isActionEventValid(actionStep, decodedLogs);
+      return this.isActionEventValid(actionStep, decodedLogs, event);
     }
     if (actionStep.signatureType === SignatureType.FUNC) {
       if ('hash' in params) {
@@ -757,20 +762,43 @@ export class EventAction extends DeployableTarget<
 
   /**
    * Validates a single action event with a given criteria against logs.
-   * If logs are provided in the optional `params` argument, then those logs will be used instead of being fetched with the configured client.
    *
    * @public
-   * @async
    * @param {ActionStep} actionStep - The action step containing the event to validate.
    * @param {EventLogs} logs - Event logs to validate the given step against
-   * @returns {Promise<boolean>} Resolves to true if the action event is valid, throws if input is invalid, otherwise false.
+   * @param {AbiEvent} eventAbi - The ABI definition of the event
+   * @returns {boolean} Resolves to true if the action event is valid, throws if input is invalid, otherwise false.
    */
-  public isActionEventValid(actionStep: ActionStep, logs: EventLogs) {
+  public isActionEventValid(
+    actionStep: ActionStep,
+    logs: EventLogs,
+    eventAbi: AbiEvent,
+  ): boolean {
     const criteria = actionStep.actionParameter;
     if (!logs.length) return false;
+
+    // Check each log
     for (let log of logs) {
-      if (this.validateLogAgainstCriteria(criteria, log)) {
-        return true;
+      // parse out final (scalar) field from the log args
+      try {
+        if (!Array.isArray(log.args)) {
+          throw new DecodedArgsMalformedError({
+            log,
+            criteria,
+            fieldValue: undefined,
+          });
+        }
+        const { value, type } = this.parseFieldFromAbi(
+          log.args,
+          criteria.fieldIndex,
+          eventAbi.inputs || [],
+          criteria.fieldType,
+        );
+        if (this.validateFieldAgainstCriteria(criteria, value, type, { log })) {
+          return true;
+        }
+      } catch {
+        // If there's an error on this log, keep trying with the next one
       }
     }
     return false;
@@ -822,7 +850,15 @@ export class EventAction extends DeployableTarget<
         return { ...log, eventName, args };
       });
 
-      return this.isActionEventValid(actionStep, decodedLogs);
+      return this.isActionEventValid(actionStep, decodedLogs, {
+        name: 'Transfer',
+        type: 'event',
+        inputs: [
+          { type: 'address', indexed: true },
+          { type: 'address', indexed: true },
+          { type: 'uint256', indexed: true },
+        ],
+      });
     } catch {
       // ERC20
       try {
@@ -845,11 +881,89 @@ export class EventAction extends DeployableTarget<
           return { ...log, eventName, args };
         });
 
-        return this.isActionEventValid(actionStep, decodedLogs);
+        return this.isActionEventValid(actionStep, decodedLogs, {
+          name: 'Transfer',
+          type: 'event',
+          inputs: [
+            { type: 'address', indexed: true },
+            { type: 'address', indexed: true },
+            { type: 'uint256' },
+          ],
+        });
       } catch {
         throw new DecodedArgsError('Failed to decode transfer logs');
       }
     }
+  }
+
+  /**
+   * Parses the final (scalar) field from a set of decoded arguments, given an ABI definition.
+   * If the fieldType is TUPLE, we decode `fieldIndex` as a bitpacked array of indexes to drill down
+   * into nested tuples. Otherwise, we parse the single `fieldIndex` as normal.
+   *
+   * @public
+   * @param {readonly unknown[]} allArgs - The decoded arguments array from an event log or function call.
+   * @param {number} criteriaIndex - The field index (bitpacked if TUPLE).
+   * @param {AbiParameter[]} abiInputs - The ABI inputs describing each decoded argument.
+   * @param {PrimitiveType} declaredType - Either TUPLE or a standard scalar type
+   * @returns {{ value: string | bigint | Hex; type: Exclude<PrimitiveType, PrimitiveType.TUPLE> }}
+   */
+  public parseFieldFromAbi(
+    allArgs: readonly unknown[],
+    criteriaIndex: number,
+    abiInputs: readonly AbiParameter[],
+    declaredType: PrimitiveType,
+  ): {
+    value: string | bigint | Hex;
+    type: Exclude<PrimitiveType, PrimitiveType.TUPLE>;
+  } {
+    // If ANY_ACTION_PARAM, return a dummy "any" value so we can do special-case checks
+    if (criteriaIndex === CheatCodes.ANY_ACTION_PARAM) {
+      return { value: zeroHash, type: PrimitiveType.BYTES };
+    }
+
+    // If it's not TUPLE, parse as a single index (existing logic)
+    if (declaredType !== PrimitiveType.TUPLE) {
+      if (!Array.isArray(allArgs) || criteriaIndex >= allArgs.length) {
+        throw new FieldValueUndefinedError({
+          fieldValue: allArgs,
+          criteria: {
+            filterType: FilterType.EQUAL,
+            fieldType: declaredType,
+            fieldIndex: criteriaIndex,
+            filterData: zeroHash,
+          },
+        });
+      }
+      const abiParam = abiInputs[criteriaIndex];
+      if (!abiParam || !abiParam.type) {
+        throw new UnparseableAbiParamError(criteriaIndex, abiParam as AbiEvent);
+      }
+      const rawValue = allArgs[criteriaIndex];
+
+      const finalType = abiTypeToPrimitiveType(abiParam.type);
+
+      if (
+        finalType === PrimitiveType.ADDRESS &&
+        (typeof rawValue !== 'string' || !isAddress(rawValue))
+      ) {
+        throw new FieldValueUndefinedError({
+          fieldValue: rawValue,
+          criteria: {
+            fieldIndex: criteriaIndex,
+            filterType: FilterType.EQUAL,
+            fieldType: finalType,
+            filterData: zeroHash,
+          },
+        });
+      }
+
+      return { value: rawValue as string | bigint | Hex, type: finalType };
+    }
+
+    // Otherwise, declaredType === TUPLE => decode bitpacked indexes
+    const indexes = unpackFieldIndexes(criteriaIndex);
+    return parseNestedTupleValue(allArgs as unknown[], indexes, abiInputs);
   }
 
   /**
@@ -871,10 +985,10 @@ export class EventAction extends DeployableTarget<
     params: Pick<ValidateActionStepParams, 'abiItem' | 'knownSignatures'>,
   ) {
     const criteria = actionStep.actionParameter;
-    let signature = actionStep.signature;
+    const signature = actionStep.signature;
 
     let func: AbiFunction;
-    if (params.abiItem) func = params?.abiItem as AbiFunction;
+    if (params.abiItem) func = params.abiItem as AbiFunction;
     else {
       const sigPool = params.knownSignatures as Record<Hex, AbiFunction>;
       func = sigPool[signature] as AbiFunction;
@@ -893,51 +1007,61 @@ export class EventAction extends DeployableTarget<
       throw new FunctionDataDecodeError([func], e as Error);
     }
 
-    // Validate the criteria against decoded arguments using fieldIndex
-    const decodedArgs = decodedData.args;
-
-    if (!decodedArgs || !decodedData) return false;
-
-    if (
-      !this.validateFunctionAgainstCriteria(
-        criteria,
-        decodedArgs as (string | bigint)[],
-      )
-    ) {
+    if (!decodedData?.args) {
       return false;
     }
 
-    return true;
+    try {
+      const { value, type } = this.parseFieldFromAbi(
+        decodedData.args as unknown[],
+        criteria.fieldIndex,
+        func.inputs || [],
+        criteria.fieldType,
+      );
+      return this.validateFieldAgainstCriteria(criteria, value, type, {
+        decodedArgs: decodedData.args as readonly (string | bigint)[],
+      });
+    } catch {
+      return false;
+    }
   }
+
   /**
-   * Validates a field against a given criteria.
+   * Validates a field against a given criteria. The field is assumed to be a non-tuple scalar,
+   * along with its final resolved `PrimitiveType`. (Any TUPLE logic has been extracted elsewhere.)
    *
    * @param {Criteria} criteria - The criteria to validate against.
    * @param {string | bigint | Hex} fieldValue - The field value to validate.
+   * @param {Exclude<PrimitiveType, PrimitiveType.TUPLE>} fieldType - The final resolved primitive type.
    * @param {Object} input - Additional context for validation.
    * @param {EventLogs[0]} [input.log] - The event log, if validating an event.
    * @param {readonly (string | bigint)[]} [input.decodedArgs] - The decoded function arguments, if validating a function call.
-   * @returns {Promise<boolean>} - Returns true if the field passes the criteria, false otherwise.
+   * @returns {boolean} - Returns true if the field passes the criteria, false otherwise.
    */
   public validateFieldAgainstCriteria(
     criteria: Criteria,
     fieldValue: string | bigint | Hex,
+    fieldType: Exclude<PrimitiveType, PrimitiveType.TUPLE>,
     input:
       | { log: EventLogs[0] }
       | { decodedArgs: readonly (string | bigint)[] },
   ): boolean {
+    /*
+     * Special-case: ANY_ACTION_PARAM. If we have filterType=EQUAL, fieldType=BYTES, fieldIndex=255,
+     * we consider that a wildcard match. Return true immediately.
+     */
     if (
       criteria.filterType === FilterType.EQUAL &&
-      criteria.fieldType === PrimitiveType.BYTES &&
+      fieldType === PrimitiveType.BYTES &&
       criteria.fieldIndex === CheatCodes.ANY_ACTION_PARAM
     ) {
       return true;
     }
 
-    // Type narrow based on criteria.filterType
+    // Evaluate filter based on the final fieldType
     switch (criteria.filterType) {
       case FilterType.EQUAL:
-        return match(criteria.fieldType)
+        return match(fieldType)
           .with(PrimitiveType.ADDRESS, () =>
             isAddressEqual(criteria.filterData, fieldValue as Address),
           )
@@ -952,7 +1076,7 @@ export class EventAction extends DeployableTarget<
           .otherwise(() => fieldValue === criteria.filterData);
 
       case FilterType.NOT_EQUAL:
-        return match(criteria.fieldType)
+        return match(fieldType)
           .with(
             PrimitiveType.ADDRESS,
             () => !isAddressEqual(criteria.filterData, fieldValue as Address),
@@ -968,7 +1092,7 @@ export class EventAction extends DeployableTarget<
           .otherwise(() => fieldValue !== criteria.filterData);
 
       case FilterType.GREATER_THAN:
-        if (criteria.fieldType === PrimitiveType.UINT) {
+        if (fieldType === PrimitiveType.UINT) {
           return BigInt(fieldValue) > BigInt(criteria.filterData);
         }
         throw new InvalidNumericalCriteriaError({
@@ -976,8 +1100,9 @@ export class EventAction extends DeployableTarget<
           criteria,
           fieldValue,
         });
+
       case FilterType.GREATER_THAN_OR_EQUAL:
-        if (criteria.fieldType === PrimitiveType.UINT) {
+        if (fieldType === PrimitiveType.UINT) {
           return BigInt(fieldValue) >= BigInt(criteria.filterData);
         }
         throw new InvalidNumericalCriteriaError({
@@ -987,7 +1112,7 @@ export class EventAction extends DeployableTarget<
         });
 
       case FilterType.LESS_THAN:
-        if (criteria.fieldType === PrimitiveType.UINT) {
+        if (fieldType === PrimitiveType.UINT) {
           return BigInt(fieldValue) < BigInt(criteria.filterData);
         }
         throw new InvalidNumericalCriteriaError({
@@ -995,8 +1120,9 @@ export class EventAction extends DeployableTarget<
           criteria,
           fieldValue,
         });
+
       case FilterType.LESS_THAN_OR_EQUAL:
-        if (criteria.fieldType === PrimitiveType.UINT) {
+        if (fieldType === PrimitiveType.UINT) {
           return BigInt(fieldValue) <= BigInt(criteria.filterData);
         }
         throw new InvalidNumericalCriteriaError({
@@ -1007,11 +1133,11 @@ export class EventAction extends DeployableTarget<
 
       case FilterType.CONTAINS:
         if (
-          criteria.fieldType === PrimitiveType.BYTES ||
-          criteria.fieldType === PrimitiveType.STRING
+          fieldType === PrimitiveType.BYTES ||
+          fieldType === PrimitiveType.STRING
         ) {
           let substring;
-          if (criteria.fieldType === PrimitiveType.STRING) {
+          if (fieldType === PrimitiveType.STRING) {
             substring = fromHex(criteria.filterData, 'string');
           } else {
             // truncate the `0x` prefix
@@ -1033,12 +1159,11 @@ export class EventAction extends DeployableTarget<
             fieldValue,
           });
         }
-
-        if (criteria.fieldType === PrimitiveType.STRING) {
-          // fieldValue is decoded by the ABI
+        if (fieldType === PrimitiveType.STRING) {
           const regexString = fromHex(criteria.filterData, 'string');
           return new RegExp(regexString).test(fieldValue);
         }
+      // Otherwise unrecognized or not applicable
 
       default:
         throw new UnrecognizedFilterTypeError({
@@ -1047,68 +1172,6 @@ export class EventAction extends DeployableTarget<
           fieldValue,
         });
     }
-  }
-
-  /**
-   * Validates a {@link Log} against a given criteria.
-   * If the criteria's fieldIndex is 255 (using CheatCodes enum), it is reserved for anyValidation
-   *
-   * @param {Criteria} criteria - The criteria to validate against.
-   * @param {Log} log - The Viem event log.
-   * @returns {boolean} - Returns true if the log passes the criteria, false otherwise.
-   */
-  public validateLogAgainstCriteria(
-    criteria: Criteria,
-    log: EventLogs[0],
-  ): boolean {
-    if (
-      !Array.isArray(log.args) ||
-      (log.args.length <= criteria.fieldIndex &&
-        criteria.fieldIndex !== CheatCodes.ANY_ACTION_PARAM)
-    ) {
-      throw new DecodedArgsMalformedError({
-        log,
-        criteria,
-        fieldValue: undefined,
-      });
-    }
-
-    const fieldValue =
-      criteria.fieldIndex === CheatCodes.ANY_ACTION_PARAM
-        ? zeroHash
-        : log.args.at(criteria.fieldIndex);
-
-    if (fieldValue === undefined) {
-      throw new FieldValueUndefinedError({ log, criteria, fieldValue });
-    }
-    return this.validateFieldAgainstCriteria(criteria, fieldValue, { log });
-  }
-
-  /**
-   * Validates a function's decoded arguments against a given criteria.
-   * If the criteria's fieldIndex is 255 (using CheatCodes enum), it is reserved for anyValidation
-   *
-   * @param {Criteria} criteria - The criteria to validate against.
-   * @param {unknown[]} decodedArgs - The decoded arguments of the function call.
-   * @returns {Promise<boolean>} - Returns true if the decoded argument passes the criteria, false otherwise.
-   */
-  public validateFunctionAgainstCriteria(
-    criteria: Criteria,
-    decodedArgs: readonly (string | bigint)[],
-  ): boolean {
-    const fieldValue =
-      criteria.fieldIndex === CheatCodes.ANY_ACTION_PARAM
-        ? zeroHash
-        : decodedArgs[criteria.fieldIndex];
-    if (fieldValue === undefined) {
-      throw new FieldValueUndefinedError({
-        criteria,
-        fieldValue,
-      });
-    }
-    return this.validateFieldAgainstCriteria(criteria, fieldValue, {
-      decodedArgs,
-    });
   }
 
   /**
@@ -1160,6 +1223,15 @@ export class EventAction extends DeployableTarget<
     };
   }
 
+  /**
+   * Determines whether a string or bytes field is indexed in the event definition.
+   * If the user tries to filter on an indexed string/bytes, we throw an error.
+   *
+   * @public
+   * @param {ActionStep} step
+   * @param {AbiEvent} event
+   * @returns {boolean}
+   */
   public isArraylikeIndexed(step: ActionStep, event: AbiEvent) {
     if (
       (step.actionParameter.fieldType === PrimitiveType.STRING ||
@@ -1172,9 +1244,114 @@ export class EventAction extends DeployableTarget<
   }
 }
 
+/**
+ * Checks if a particular ABI parameter is the "tuple" variant that can have `components`.
+ *
+ * @param {AbiParameter} param
+ * @returns {boolean}
+ */
+function isTupleAbiParameter(
+  param: AbiParameter,
+): param is Extract<AbiParameter, { components: readonly AbiParameter[] }> {
+  return param.type === 'tuple' || param.type.startsWith('tuple[');
+}
+
+/**
+ * Recursively parses nested tuples by following an array of sub-indexes (unpacked from bitpacked `fieldIndex`).
+ * Each entry in `indexes` is used to pick which sub-component in the current tuple's `components`.
+ * If we encounter the "terminator" or run out of indexes, we stop.
+ *
+ * @param {unknown[]} rawArgs - The top-level arguments array.
+ * @param {number[]} indexes - The array of indexes from `unpackFieldIndexes(...)`.
+ * @param {readonly AbiParameter[]} abiInputs - The top-level ABI inputs for the entire arguments array.
+ * @returns {{ value: string | bigint | Hex, type: Exclude<PrimitiveType, PrimitiveType.TUPLE> }}
+ */
+function parseNestedTupleValue(
+  rawArgs: unknown[],
+  indexes: number[],
+  abiInputs: readonly AbiParameter[],
+): {
+  value: string | bigint | Hex;
+  type: Exclude<PrimitiveType, PrimitiveType.TUPLE>;
+} {
+  if (!indexes.length) {
+    throw new Error(`No indexes found; cannot parse TUPLE field`);
+  }
+
+  // The first index picks which top-level ABI param to look at
+  const idx = indexes[0] ?? abiInputs.length + 1;
+  // If idx is out of range or is a "terminator," fail fast
+  if (idx >= abiInputs.length) {
+    throw new Error(`Tuple index ${idx} is out of range for ABI inputs`);
+  }
+
+  const param = abiInputs[idx];
+  const rawValue = rawArgs[idx];
+
+  // If param isn't a tuple, we are at a leaf
+  if (!isTupleAbiParameter(param!)) {
+    const finalType = abiTypeToPrimitiveType(param!.type);
+    return { value: rawValue as string | bigint | Hex, type: finalType };
+  }
+
+  // Otherwise param is a tuple => rawValue must be an array of subfields
+  if (!Array.isArray(rawValue)) {
+    throw new Error(`rawValue is not an array, but param.type is tuple`);
+  }
+
+  // Move to the next sub-index
+  const remaining = indexes.slice(1);
+  if (!remaining.length) {
+    // If there are no more indexes, we can't pick a sub-component
+    // Typically you'd want at least one more index to say "which subfield in the tuple we want"
+    throw new Error(
+      `No sub-index provided to pick a sub-component in nested tuple`,
+    );
+  }
+
+  // Check the next index for param.components
+  const subIdx = remaining[0] ?? param.components.length + 1;
+  if (subIdx >= param.components.length) {
+    throw new Error(
+      `Tuple sub-index ${subIdx} out of range for param.components`,
+    );
+  }
+
+  // Recurse deeper using param.components as the "new top-level" ABI param list
+  return parseNestedTupleValue(rawValue, remaining, param.components);
+}
+
+/**
+ * Maps an ABI type string (e.g. 'uint256', 'address', 'bytes', 'string', etc.) to a `PrimitiveType`.
+ *
+ * @param {string} abiType
+ * @returns {Exclude<PrimitiveType, PrimitiveType.TUPLE>}
+ */
+function abiTypeToPrimitiveType(
+  abiType: string,
+): Exclude<PrimitiveType, PrimitiveType.TUPLE> {
+  const lower = abiType.toLowerCase();
+
+  if (lower.startsWith('uint') || lower.startsWith('int')) {
+    return PrimitiveType.UINT;
+  }
+  if (lower === 'address') {
+    return PrimitiveType.ADDRESS;
+  }
+  if (lower === 'bytes' || lower.startsWith('bytes')) {
+    return PrimitiveType.BYTES;
+  }
+  if (lower === 'string') {
+    return PrimitiveType.STRING;
+  }
+
+  // If it doesn't match any known scalar, throw. We expect parseNestedTupleValue() to handle nested tuple logic separately.
+  throw new Error(`Unrecognized ABI type: ${abiType}`);
+}
+
 function _dedupeActionSteps(_steps: ActionStep[]): ActionStep[] {
-  const steps: ActionStep[] = [],
-    signatures: Record<string, boolean> = {};
+  const steps: ActionStep[] = [];
+  const signatures: Record<string, boolean> = {};
   for (let step of _steps) {
     const signature = JSON.stringify(step);
     if (signatures[signature]) continue;
@@ -1183,6 +1360,7 @@ function _dedupeActionSteps(_steps: ActionStep[]): ActionStep[] {
   }
   return steps;
 }
+
 type RawActionStep = Overwrite<ActionStep, { chainid: bigint }>;
 type RawActionClaimant = Overwrite<ActionClaimant, { chainid: bigint }>;
 
@@ -1426,4 +1604,48 @@ export function transactionSenderClaimant(chainId: number): ActionClaimant {
     targetContract: zeroAddress,
     chainid: chainId,
   };
+}
+
+// Helper functions to bit-pack and decode fieldIndex values
+const MAX_FIELD_INDEX = 0b111111; // Maximum value for 6 bits (63)
+
+/**
+ * Packs up to five indexes into a single uint32 value.
+ *
+ * @param {number[]} indexes - Array of up to five indexes to pack.
+ * @returns {number} - Packed uint32 value.
+ * @throws {Error} - If more than five indexes are provided or an index exceeds the maximum value.
+ */
+export function packFieldIndexes(indexes: number[]): number {
+  if (indexes.length > 5) {
+    throw new Error('Can only pack up to 5 indexes.');
+  }
+
+  let packed = 0;
+  indexes.forEach((index, i) => {
+    if (index > MAX_FIELD_INDEX) {
+      throw new Error(
+        `Index ${index} exceeds the maximum allowed value (${MAX_FIELD_INDEX}).`,
+      );
+    }
+    packed |= (index & MAX_FIELD_INDEX) << (i * 6); // Each index occupies 6 bits
+  });
+
+  return packed;
+}
+
+/**
+ * Unpacks a uint32 fieldIndex value into an array of up to five indexes.
+ *
+ * @param {number} packed - Packed uint32 value.
+ * @returns {number[]} - Array of unpacked indexes.
+ */
+export function unpackFieldIndexes(packed: number): number[] {
+  const indexes: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const index = (packed >> (i * 6)) & MAX_FIELD_INDEX;
+    if (index === MAX_FIELD_INDEX) break; // Terminator value
+    indexes.push(index);
+  }
+  return indexes;
 }

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -88,6 +88,7 @@ export enum PrimitiveType {
   ADDRESS = 1,
   BYTES = 2,
   STRING = 3,
+  TUPLE = 4,
 }
 
 /**

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1061,8 +1061,9 @@ export class EventAction extends DeployableTarget<
       return true;
     }
     if (criteria.fieldType === PrimitiveType.TUPLE) {
-      // May want an error here?
-      return false;
+      throw new InvalidTupleDecodingError(
+        'Tuples should not be passed into validateFieldAgainstCriteria',
+      );
     }
     const fieldType = criteria.fieldType;
 

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -794,7 +794,8 @@ export class EventAction extends DeployableTarget<
           eventAbi.inputs || [],
           criteria.fieldType,
         );
-        if (this.validateFieldAgainstCriteria(criteria, value, type, { log })) {
+        criteria.fieldType = type;
+        if (this.validateFieldAgainstCriteria(criteria, value, { log })) {
           return true;
         }
       } catch {
@@ -1018,7 +1019,8 @@ export class EventAction extends DeployableTarget<
         func.inputs || [],
         criteria.fieldType,
       );
-      return this.validateFieldAgainstCriteria(criteria, value, type, {
+      criteria.fieldType = type;
+      return this.validateFieldAgainstCriteria(criteria, value, {
         decodedArgs: decodedData.args as readonly (string | bigint)[],
       });
     } catch {
@@ -1041,7 +1043,6 @@ export class EventAction extends DeployableTarget<
   public validateFieldAgainstCriteria(
     criteria: Criteria,
     fieldValue: string | bigint | Hex,
-    fieldType: Exclude<PrimitiveType, PrimitiveType.TUPLE>,
     input:
       | { log: EventLogs[0] }
       | { decodedArgs: readonly (string | bigint)[] },
@@ -1052,11 +1053,16 @@ export class EventAction extends DeployableTarget<
      */
     if (
       criteria.filterType === FilterType.EQUAL &&
-      fieldType === PrimitiveType.BYTES &&
+      criteria.fieldType === PrimitiveType.BYTES &&
       criteria.fieldIndex === CheatCodes.ANY_ACTION_PARAM
     ) {
       return true;
     }
+    if (criteria.fieldType === PrimitiveType.TUPLE) {
+      // May want an error here?
+      return false;
+    }
+    const fieldType = criteria.fieldType;
 
     // Evaluate filter based on the final fieldType
     switch (criteria.filterType) {
@@ -1447,7 +1453,7 @@ export function prepareEventActionPayload({
                 components: [
                   { type: 'uint8', name: 'filterType' },
                   { type: 'uint8', name: 'fieldType' },
-                  { type: 'uint8', name: 'fieldIndex' },
+                  { type: 'uint32', name: 'fieldIndex' },
                   { type: 'bytes', name: 'filterData' },
                 ],
               },
@@ -1468,7 +1474,7 @@ export function prepareEventActionPayload({
                 components: [
                   { type: 'uint8', name: 'filterType' },
                   { type: 'uint8', name: 'fieldType' },
-                  { type: 'uint8', name: 'fieldIndex' },
+                  { type: 'uint32', name: 'fieldIndex' },
                   { type: 'bytes', name: 'filterData' },
                 ],
               },
@@ -1489,7 +1495,7 @@ export function prepareEventActionPayload({
                 components: [
                   { type: 'uint8', name: 'filterType' },
                   { type: 'uint8', name: 'fieldType' },
-                  { type: 'uint8', name: 'fieldIndex' },
+                  { type: 'uint32', name: 'fieldIndex' },
                   { type: 'bytes', name: 'filterData' },
                 ],
               },
@@ -1510,7 +1516,7 @@ export function prepareEventActionPayload({
                 components: [
                   { type: 'uint8', name: 'filterType' },
                   { type: 'uint8', name: 'fieldType' },
-                  { type: 'uint8', name: 'fieldIndex' },
+                  { type: 'uint32', name: 'fieldIndex' },
                   { type: 'bytes', name: 'filterData' },
                 ],
               },

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -865,3 +865,53 @@ export class BoostNotFoundError extends Error {
     this.id = id;
   }
 }
+
+/**
+ * Thrown when a tuple decoding operation encounters unexpected structure or data.
+ *
+ * @export
+ * @class InvalidTupleDecodingError
+ * @typedef {InvalidTupleDecodingError}
+ * @extends {Error}
+ */
+export class InvalidTupleDecodingError extends Error {
+  /**
+   * The index of the tuple that caused the error.
+   *
+   * @type {number}
+   */
+  public readonly tupleIndex: number;
+
+  /**
+   * Creates an instance of InvalidTupleDecodingError.
+   *
+   * @constructor
+   * @param {string} tupleName - The name or identifier of the tuple that failed to decode.
+   * @param {string} [message] - Optional custom message for more context.
+   */
+  constructor(message?: string, tupleIndex?: number) {
+    super(message || `Failed to decode tuple: ${tupleIndex}`);
+    this.tupleIndex = tupleIndex ?? -1;
+  }
+}
+
+export class InvalidTupleEncodingError extends Error {
+  /**
+   * The index of the tuple that caused the error.
+   *
+   * @type {number}
+   */
+  public readonly tupleIndex: number;
+
+  /**
+   * Creates an instance of InvalidTupleEncodingError.
+   *
+   * @constructor
+   * @param {string} tupleName - The name or identifier of the tuple that failed to encode.
+   * @param {string} [message] - Optional custom message for more context.
+   */
+  constructor(message?: string, tupleIndex?: number) {
+    super(message || `Failed to encode tuple: ${tupleIndex}`);
+    this.tupleIndex = tupleIndex ?? -1;
+  }
+}


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description

1. **Nested Tuple Support:**  
   - Added logic for *bit-packed* `fieldIndex` when the `fieldType` is `TUPLE`.  
   - Each sub-index is stored in a 6-bit segment, so we can drill through up to five nesting levels.  
   - A value of **63** (the maximum 6-bit integer) acts as a terminator indicating “no further indexes.”

2. **Final Primitive Resolution:**  
   - When the parser encounters a tuple in the ABI, it recursively unpacks each sub-index to select the correct sub-component.  
   - At the last nested component (a leaf), we derive the real `PrimitiveType` (e.g., `ADDRESS`, `UINT`, `BYTES`, `STRING`) by inspecting the ABI definition.

3. **Refactored Parse and Validation Flows:**  
   - `parseFieldFromAbi` handles all the tuple logic, returning a final scalar plus its derived type.  
   - `isActionEventValid` and `isActionFunctionValid` each call `parseFieldFromAbi` before calling `validateFieldAgainstCriteria`.

4. **Tests and Examples:**  
   - New tests cover the bit-packing/unpacking (via `packFieldIndexes`/`unpackFieldIndexes`) and tuple parsing across multiple levels of nesting.  
   - Included a new readme section illustrating how the 6-bit indexes are combined and how tuples are drilled down.

## Tuple Handling
When a field is declared as TUPLE in the `PrimitiveType` of an `EventAction`, we unpack its bit-packed fieldIndex to drill down through each nested level of the tuple. Each sub-index occupies 6 bits (values 0–63), and a sub-index of 63 is treated as a terminator—signaling the end of further drilling. Once we locate the leaf in the nested structure, the code infers the final (non-tuple) PrimitiveType by reading the ABI definition (address, uint256, string, etc.) at that leaf node.
1. We can store up to 5 sub-indexes (each 6 bits) in one fieldIndex.
1. As we parse a TUPLE, we read those sub-indexes one by one, traversing each nested tuple parameter in the ABI.
1. At the final, non-tuple component, we derive the actual PrimitiveType (e.g., ADDRESS, UINT, BYTES, or STRING) by inspecting that component’s type in the ABI definition.

