### PR TITLE
[BOOST-5140] add `getIncentiveFeesInfo` sdk method to boostcore

### DIFF
--- a/.changeset/mighty-snakes-leave.md
+++ b/.changeset/mighty-snakes-leave.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+add method for getIncentiveFeesInfo on boostcore

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -17,6 +17,7 @@ import { BoostNotFoundError, IncentiveNotCloneableError } from "./errors";
 import type { ERC20Incentive } from "./Incentives/ERC20Incentive";
 import { bytes4 } from "./utils";
 import { BoostValidatorEOA } from "./Validators/Validator";
+import { AssetType } from "./transfers";
 
 let fixtures: Fixtures, budgets: BudgetFixtures;
 
@@ -944,6 +945,7 @@ describe("BoostCore", () => {
     expect(feesInfo).toBeDefined();
     expect(feesInfo.protocolFee).toBe(1000n);
     expect(feesInfo.protocolFeesRemaining).toBe(parseEther("1"));
+    expect(feesInfo.assetType).toBe(AssetType.ERC20);
     expect(feesInfo.asset.toLowerCase()).toBe(erc20.assertValidAddress());
   });
 });

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -129,6 +129,7 @@ import {
   InvalidProtocolChainIdError,
   MustInitializeBudgetError,
 } from './errors';
+import type { AssetType } from './transfers';
 import {
   type GenericLog,
   type ReadParams,
@@ -277,18 +278,6 @@ export type CreateBoostPayload = {
   maxParticipants?: bigint;
   owner?: Address;
 };
-
-/**
- * Enum representing the asset types for incentives.
- *
- * @export
- * @enum {number}
- */
-export enum AssetType {
-  ERC20 = 0,
-  ERC1155 = 1,
-  ETH = 2,
-}
 
 /**
  * Represents the information about the disbursal of an incentive.

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -3,6 +3,7 @@ import {
   readBoostCoreCreateBoostAuth,
   readBoostCoreGetBoost,
   readBoostCoreGetBoostCount,
+  readBoostCoreGetIncentiveFeesInfo,
   readBoostCoreProtocolFee,
   readBoostCoreProtocolFeeReceiver,
   readIAuthIsAuthorized,
@@ -29,6 +30,8 @@ import {
   type Address,
   type ContractEventName,
   type Hex,
+  encodePacked,
+  keccak256,
   parseEventLogs,
   zeroAddress,
   zeroHash,
@@ -273,6 +276,32 @@ export type CreateBoostPayload = {
   protocolFee?: bigint;
   maxParticipants?: bigint;
   owner?: Address;
+};
+
+/**
+ * Enum representing the asset types for incentives.
+ *
+ * @export
+ * @enum {number}
+ */
+export enum AssetType {
+  ERC20 = 0,
+  ERC1155 = 1,
+  ETH = 2,
+}
+
+/**
+ * Represents the information about the disbursal of an incentive.
+ *
+ * @export
+ * @typedef {IncentiveDisbursalInfo}
+ */
+export type IncentiveDisbursalInfo = {
+  assetType: AssetType;
+  asset: Address;
+  protocolFeesRemaining: bigint;
+  protocolFee: bigint;
+  tokenId: bigint;
 };
 
 /**
@@ -1044,6 +1073,38 @@ export class BoostCore extends Deployable<
       request,
     );
     return { hash, result };
+  }
+
+  /**
+   * Get the incentives fees information for a given Boost ID and Incentive ID.
+   *
+   * @public
+   * @async
+   * @param {bigint} boostId - The ID of the Boost
+   * @param {bigint} incentiveId - The ID of the Incentive
+   * @param {?ReadParams} [params]
+   * @returns {Promise<IncentiveDisbursalInfo>}
+   */
+  public async getIncentiveFeesInfo(
+    boostId: bigint,
+    incentiveId: bigint,
+    params?: ReadParams,
+  ) {
+    const key = keccak256(
+      encodePacked(['uint256', 'uint256'], [boostId, incentiveId]),
+    );
+
+    return await readBoostCoreGetIncentiveFeesInfo(this._config, {
+      ...assertValidAddressByChainId(
+        this._config,
+        this.addresses,
+        params?.chainId,
+      ),
+      args: [key],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
   }
 
   /**


### PR DESCRIPTION
### Description

- adds `getIncentiveFeesInfo` method to sdk
- ~~adds enum for AssetType~~ 
- add test for functionality


