### PR TITLE
[BOOST-5108] fix order of indexed params in events to match abi

### DIFF
--- a/.changeset/bright-kids-pay.md
+++ b/.changeset/bright-kids-pay.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+reorder abiparams with indexed values to match decoded logs

--- a/.changeset/bright-kids-pay.md
+++ b/.changeset/bright-kids-pay.md
@@ -2,4 +2,4 @@
 "@boostxyz/sdk": minor
 ---
 
-reorder abiparams with indexed values to match decoded logs
+reorder event args params in decoded logs to match abi params

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1419,4 +1419,31 @@ describe('decodeAndReorderLogArgs', () => {
     expect(Array.isArray(result.args[4]));
     expect(result.args[5]).toBe(0n);
   });
+
+  test('correctly reorders mixed indexed and non-indexed parameters', () => {
+    const event = eventAbi['NameRegistered(string,bytes32 indexed,address indexed,uint256)'] as AbiEvent;
+
+    const log: Log = {
+      address: "0x4ccb0bb02fcaba27e82a56646e81d8c5bc4119a5",
+      blockHash: "0xd3756b6a35ebee1bfcf66b605dc3bd6fc85ca282ed94b190b25db4c6b3ef188a",
+      blockNumber: 23536079n,
+      data: "0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000693a2861000000000000000000000000000000000000000000000000000000000000000c626f6f73742d6d61747469650000000000000000000000000000000000000000",
+      logIndex: 133,
+      removed: false,
+      topics: [
+        "0x0667086d08417333ce63f40d5bc2ef6fd330e25aaaf317b7c489541f8fe600fa",
+        "0x82de51675fd710fc7a247469e170340787130a61b84dc3446b63277e03e4abd9",
+        "0x000000000000000000000000865c301c46d64de5c9b124ec1a97ef1efc1bcbd1"
+      ],
+      transactionHash: "0xbe54acb2ceb28e7eb962e09218d51ab3369139ac3fd782cacccf163f0daf1a08",
+      transactionIndex: 26,
+    };
+
+    const result = decodeAndReorderLogArgs(event, log);
+
+    expect(result.args[0]).toBe("boost-mattie");
+    expect(result.args[1]).toBe("0x82de51675fd710fc7a247469e170340787130a61b84dc3446b63277e03e4abd9");
+    expect(result.args[2]).toBe("0x865C301c46d64DE5c9B124Ec1a97eF1EFC1bcbd1");
+    expect(result.args[3]).toBe(1765419105n);
+  });
 }); 

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -5,12 +5,12 @@ import {
 import { selectors as funcSelectors } from "@boostxyz/signatures/functions";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import {
-  AbiEvent,
+  type AbiEvent,
   type Address,
+  type Log,
   type Hex,
   isAddress,
   isAddressEqual,
-  Log,
   parseEther,
   toHex,
   zeroAddress,

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1446,4 +1446,35 @@ describe('decodeAndReorderLogArgs', () => {
     expect(result.args[2]).toBe("0x865C301c46d64DE5c9B124Ec1a97eF1EFC1bcbd1");
     expect(result.args[3]).toBe(1765419105n);
   });
+
+  test('works with events where params are already correctly ordered', () => {
+    const event = eventAbi["BoostCreated(uint256 indexed,address indexed,address indexed,uint256,address,address,address)"] as AbiEvent;
+
+    const log: Log = {
+      address: "0xdcffce9d8185706780a46cf04d9c6b86b3451497",
+      blockHash: "0xdfcbc66fc07d41321badb8f8afa3e8fea3f65e87791d3de1ad07d470b2ff1c8e",
+      blockNumber: 7449080n,
+      data: "0x0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000e81490c0b9e625999c78f155c7bcf7f11f512b390000000000000000000000003322baef13ac75b1b1e25abc65c0df28f9e55670000000000000000000000000d1513f67da84dec0759f6a715bf28a637c7de716",
+      logIndex: 141,
+      removed: false,
+      topics: [
+        "0x116812d3ad4507d72f2c428b63246d594ca055a1dc119394285504c23d1f34cd",
+        "0x000000000000000000000000000000000000000000000000000000000000006f",
+        "0x0000000000000000000000000000c1e5c9d12c8c52eb319af11da44bb84779d2",
+        "0x0000000000000000000000008b1646483aeedd894feb417da1f5a7ab1846e81e"
+      ],
+      transactionHash: "0xb23270a738440be31b2e6c2e1180324f04159d7bfd681564e877d8675fd8b5c2",
+      transactionIndex: 79,
+    };
+
+    const result = decodeAndReorderLogArgs(event, log);
+
+    expect(result.args[0]).toBe(111n);
+    expect(result.args[1]).toBe("0x0000c1E5C9d12c8c52eb319AF11dA44bb84779d2");
+    expect(result.args[2]).toBe("0x8B1646483aEedd894feB417dA1f5a7Ab1846E81E");
+    expect(result.args[3]).toBe(1n);
+    expect(result.args[4]).toBe("0xE81490c0b9e625999C78f155c7bCf7f11f512B39");
+    expect(result.args[5]).toBe("0x3322BaEf13ac75B1b1E25Abc65c0dF28f9e55670");
+    expect(result.args[6]).toBe("0xD1513f67da84DEc0759F6a715BF28A637c7de716");
+  });
 }); 

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1477,4 +1477,29 @@ describe('decodeAndReorderLogArgs', () => {
     expect(result.args[5]).toBe("0x3322BaEf13ac75B1b1E25Abc65c0dF28f9e55670");
     expect(result.args[6]).toBe("0xD1513f67da84DEc0759F6a715BF28A637c7de716");
   });
+
+  test('works with events where there is no indexed params', () => {
+    const event = eventAbi['Minted(uint8,address,uint256,uint256)'] as AbiEvent;
+
+    const log: Log = {
+      address: "0x45ecff1c647a32455ced5c21400fe61aa2be680b",
+      blockHash: "0xc5b14f59a5bc89e6a6ecdd595d4d10d1dd82adc624a04717fdff78bbb9dac988",
+      blockNumber: 24749935n,
+      data: "0x0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000865c301c46d64de5c9b124ec1a97ef1efc1bcbd1000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000014a4",
+      logIndex: 188,
+      removed: false,
+      topics: [
+        "0x7ac572687bf4e66a8514fc2ec464fc2644c78bcb1d80a225fc51a33e0ee38bfa"
+      ],
+      transactionHash: "0x0e4aba5edcbfff24d25290066b992ef5670a00864febe38ffaeb8cb1476faa96",
+      transactionIndex: 42,
+    };
+
+    const result = decodeAndReorderLogArgs(event, log);
+
+    expect(result.args[0]).toBe(1);
+    expect(result.args[1]).toBe("0x865C301c46d64DE5c9B124Ec1a97eF1EFC1bcbd1");
+    expect(result.args[2]).toBe(1n);
+    expect(result.args[3]).toBe(5284n);
+  });
 }); 

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1420,4 +1420,3 @@ describe('decodeAndReorderLogArgs', () => {
     expect(result.args[5]).toBe(0n);
   });
 }); 
-

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1665,20 +1665,7 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     : Object.values(decodedLog.args);
 
   if (!event.inputs.some((input) => input.indexed)) {
-    return {
-      ...log,
-      eventName: decodedLog.eventName,
-      args: argsArray,
-      blockHash: log.blockHash ?? zeroHash,
-      blockNumber: log.blockNumber ?? 0n,
-      logIndex: log.logIndex ?? 0,
-      transactionHash: log.transactionHash ?? zeroHash,
-      transactionIndex: log.transactionIndex ?? 0,
-      address: log.address,
-      data: log.data,
-      removed: log.removed ?? false,
-      topics: log.topics,
-    };
+    return decodedLog as EventLogs[0];
   }
 
   const indexedIndices: number[] = [];
@@ -1708,14 +1695,5 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     ...log,
     eventName: decodedLog.eventName,
     args: reorderedArgs,
-    blockHash: log.blockHash ?? zeroHash,
-    blockNumber: log.blockNumber ?? 0n,
-    logIndex: log.logIndex ?? 0,
-    transactionHash: log.transactionHash ?? zeroHash,
-    transactionIndex: log.transactionIndex ?? 0,
-    address: log.address,
-    data: log.data,
-    removed: log.removed ?? false,
-    topics: log.topics,
-  };
+  } as EventLogs[0];
 }

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1651,7 +1651,7 @@ export function unpackFieldIndexes(packed: number): number[] {
  *
  * @param event - The event ABI definition
  * @param log - The log to decode
- * @returns The decoded log with arguments in the original ABI order
+ * @returns {EventLogs[0]} The decoded log with arguments in the original ABI order
  */
 export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
   const decodedLog = decodeEventLog({

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1685,7 +1685,6 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     mapping.forEach((originalIndex, viemIndex) => {
       finalMapping[originalIndex] = viemIndex;
     });
-
     reorderedArgs = finalMapping.map((i) => argsArray[i]);
   }
 

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -333,6 +333,13 @@ export interface EventActionPayloadRaw {
 export type EventLogs = GetLogsReturnType<AbiEvent, AbiEvent[], true>;
 
 /**
+ * Single event log
+ * @export
+ * @typedef {EventLog}
+ */
+export type EventLog = EventLogs[0] & { args: unknown[] };
+
+/**
  * A generic event action
  *
  * @export
@@ -1651,7 +1658,7 @@ export function unpackFieldIndexes(packed: number): number[] {
  *
  * @param event - The event ABI definition
  * @param log - The log to decode
- * @returns {EventLogs[0]} The decoded log with arguments in the original ABI order
+ * @returns {EventLog} The decoded log with arguments in the original ABI order
  */
 export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
   const decodedLog = decodeEventLog({
@@ -1665,7 +1672,7 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     : Object.values(decodedLog.args);
 
   if (!event.inputs.some((input) => input.indexed)) {
-    return decodedLog as EventLogs[0];
+    return decodedLog as EventLog;
   }
 
   const indexedIndices: number[] = [];
@@ -1695,5 +1702,5 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     ...log,
     eventName: decodedLog.eventName,
     args: reorderedArgs,
-  } as EventLogs[0];
+  } as EventLog;
 }

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -7,6 +7,7 @@ import {
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
 import { getTransaction, getTransactionReceipt } from '@wagmi/core';
+import type { AbiEventParameter } from 'abitype';
 import { match } from 'ts-pattern';
 import {
   type AbiEvent,
@@ -1287,6 +1288,17 @@ function parseNestedTupleValue(
     throw new InvalidTupleDecodingError(
       `No indexes found; cannot parse TUPLE field`,
     );
+  }
+
+  // If the event abi has indexed parameters, we need to reorder the inputs so that indexed params are first
+  if (abiInputs.some((input) => (input as AbiEventParameter).indexed)) {
+    const indexedInputs = abiInputs.filter(
+      (input) => (input as AbiEventParameter).indexed,
+    );
+    const nonIndexedInputs = abiInputs.filter(
+      (input) => !(input as AbiEventParameter).indexed,
+    );
+    abiInputs = [...indexedInputs, ...nonIndexedInputs];
   }
 
   // The first index picks which top-level ABI param to look at


### PR DESCRIPTION
### Description
- adds a helper to re-organize event args to match the structure of the abi. 
- added multiple tests to ensure the correct order and that it will not effect events that do not have indexed params.
