### PR TITLE
[BOOST-5185] fix `getRemainingClaimPotential` on ERC20Pegged

### DIFF
--- a/.changeset/clean-items-pay.md
+++ b/.changeset/clean-items-pay.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fix getRemainingClaims on ERC20PeggedIncentive

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -422,11 +422,11 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    * @returns {Promise<bigint>} - True if total claims is less than limit
    */
   public async getRemainingClaimPotential(params?: ReadParams) {
-    const [claims, limit] = await Promise.all([
-      this.claims(params),
+    const [totalClaimed, limit] = await Promise.all([
+      this.totalClaimed(params),
       this.limit(params),
     ]);
-    return limit - claims;
+    return limit - totalClaimed;
   }
 
   /**


### PR DESCRIPTION
### Description
- updates the calculation in the ERC20PeggedIncentive method `getRemainingClaimPotential` to use `totalClaimed` instead of `claims`.
