### PR TITLE
[BOOST-5197] update transfer signature logic to allow for deriving claimant

### DIFF
--- a/.changeset/cold-days-yell.md
+++ b/.changeset/cold-days-yell.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fix transfer signature issue in deriveActionClaimantFromTransaction method

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1664,7 +1664,7 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     }
   }
 
-  const reorderedArgs = new Array(event.inputs.length);
+  const reorderedArgs = Array.from({ length: event.inputs.length });
   let currentIndex = 0;
 
   // Place the indexed arguments in their original positions


### PR DESCRIPTION
### Description
- removes event action validation from `decodeTransferLogs` method
- applies `decodeTransferLogs` in the `deriveActionClaimantFromTransaction` method
- fixes lint warning in `decodeAndReorderLogArgs` *Do not use new Array(singleArgument)*
- tested locally
