### PR TITLE
[BOOST-5209] fix: signature event issue address undefined is invalid

### DIFF
--- a/.changeset/cool-turkeys-punch.md
+++ b/.changeset/cool-turkeys-punch.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fix undefined address in address comparison

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1672,7 +1672,10 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
     : Object.values(decodedLog.args);
 
   if (!event.inputs.some((input) => input.indexed)) {
-    return decodedLog as EventLog;
+    return {
+      ...log,
+      ...decodedLog,
+    } as EventLog;
   }
 
   const indexedIndices: number[] = [];


### PR DESCRIPTION
### Description
- fixes issue with address "undefined" in claimant address comparison


