### PR TITLE
[BOOST-5224] feat(evm): add topup functionality to core

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -637,7 +637,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
     function _getFeeDisbursal(bytes memory preflight, uint64 _protocolFee)
         internal
         view
-        returns (bytes memory, uint256, uint256)
+        returns (bytes memory, uint256)
     {
         // Decode the preflight data to extract the transfer details
         ABudget.Transfer memory request = abi.decode(preflight, (ABudget.Transfer));
@@ -658,7 +658,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
             request.target = address(this); // Set the target to BoostCore (this contract)
 
             // Encode and return the modified request as bytes
-            return (abi.encode(request), feeAmount, payload.amount);
+            return (abi.encode(request), feeAmount);
         } else if (request.assetType == ABudget.AssetType.ERC1155) {
             // Decode the ERC1155 payload
             ABudget.ERC1155Payload memory payload = abi.decode(request.data, (ABudget.ERC1155Payload));
@@ -678,7 +678,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
             request.target = address(this); // Set the target to BoostCore (this contract)
 
             // Encode and return the modified request as bytes
-            return (abi.encode(request), feeAmount, payload.amount);
+            return (abi.encode(request), feeAmount);
         } else {
             revert BoostError.NotImplemented();
         }

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -307,24 +307,25 @@ contract BoostCore is Ownable, ReentrancyGuard {
         }
         ABudget.Transfer memory request = abi.decode(preflightData, (ABudget.Transfer));
 
+        uint256 topupAmount;
+        uint256 fee;
         uint256 totalAmount;
-        uint256 tokenId; // for ERC1155
         if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
             ABudget.FungiblePayload memory payload = abi.decode(request.data, (ABudget.FungiblePayload));
-            totalAmount = payload.amount;
-            IERC20 token = IERC20(request.asset);
-            token.transferFrom(msg.sender, address(this), totalAmount);
+            topupAmount = payload.amount;
+            fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
+            totalAmount = topupAmount + fee;
+            payload.amount = totalAmount;
         } else if (request.assetType == ABudget.AssetType.ERC1155) {
             ABudget.ERC1155Payload memory payload = abi.decode(request.data, (ABudget.ERC1155Payload));
-            totalAmount = payload.amount;
-            tokenId = payload.tokenId;
-            IERC1155(request.asset).safeTransferFrom(msg.sender, address(this), tokenId, totalAmount, "");
+            topupAmount = payload.amount;
+            fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
+            totalAmount = topupAmount + fee;
+            payload.amount = totalAmount;
         } else {
             revert BoostError.NotImplemented();
         }
 
-        uint256 fee = (totalAmount * boost.protocolFee) / FEE_DENOMINATOR;
-        uint256 remainder = totalAmount - fee;
 
         {
             bytes32 key = _generateKey(boostId, incentiveId);
@@ -332,21 +333,21 @@ contract BoostCore is Ownable, ReentrancyGuard {
             info.protocolFeesRemaining += fee;
         }
 
-        if (remainder > 0) {
+        if (topupAmount > 0) {
             {
                 if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
                     IERC20 token = IERC20(request.asset);
-                    token.approve(address(incentiveContract), remainder);
-                    IToppable(address(incentiveContract)).topup(remainder);
+                    token.approve(address(incentiveContract), topupAmount);
+                    IToppable(address(incentiveContract)).topup(topupAmount);
                     token.approve(address(incentiveContract), 0);
                 } else {
                     IERC1155 erc1155 = IERC1155(request.asset);
                     erc1155.setApprovalForAll(address(incentiveContract), true);
-                    IToppable(address(incentiveContract)).topup(remainder);
+                    IToppable(address(incentiveContract)).topup(topupAmount);
                     erc1155.setApprovalForAll(address(incentiveContract), false);
                 }
             }
-            emit BoostToppedUp(boostId, incentiveId, msg.sender, remainder, fee);
+            emit BoostToppedUp(boostId, incentiveId, msg.sender, topupAmount, fee);
         }
     }
 

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -328,7 +328,6 @@ contract BoostCore is Ownable, ReentrancyGuard {
             revert BoostError.NotImplemented();
         }
 
-
         {
             bytes32 key = _generateKey(boostId, incentiveId);
             IncentiveDisbursalInfo storage info = incentivesFeeInfo[key];
@@ -636,7 +635,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
 
         bytes memory preflight = incentive.preflight(incentiveParams);
         if (preflight.length != 0) {
-            (bytes memory disbursal, uint256 feeAmount, ) = _getFeeDisbursal(preflight, protocolFee_);
+            (bytes memory disbursal, uint256 feeAmount) = _getFeeDisbursal(preflight, protocolFee_);
             if (!budget_.disburse(disbursal)) revert BoostError.InvalidInitialization();
             if (!budget_.disburse(preflight)) revert BoostError.InvalidInitialization();
 

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -227,46 +227,47 @@ contract BoostCore is Ownable, ReentrancyGuard {
 
         ABudget.Transfer memory request = abi.decode(preflightData, (ABudget.Transfer));
 
-        // Redirect the disbursement to this contract so we have the funds to topup and reserve the protocol fee
-        request.target = address(this);
-        bytes memory revisedRequest = abi.encode(request);
-
         ABudget budget_ = (budget == address(0)) ? boost.budget : ABudget(payable(budget));
         _checkBudget(budget_);
-        if (!budget_.disburse(revisedRequest)) {
-            revert BoostError.InvalidInitialization();
-        }
 
-        uint256 totalAmount;
+        uint256 topupAmount;
         if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
             ABudget.FungiblePayload memory payload = abi.decode(request.data, (ABudget.FungiblePayload));
-            totalAmount = payload.amount;
+            topupAmount = payload.amount;
         } else if (request.assetType == ABudget.AssetType.ERC1155) {
             ABudget.ERC1155Payload memory payload = abi.decode(request.data, (ABudget.ERC1155Payload));
-            totalAmount = payload.amount;
+            topupAmount = payload.amount;
         } else {
             revert BoostError.NotImplemented();
         }
 
-        uint256 fee = (totalAmount * boost.protocolFee) / FEE_DENOMINATOR;
-        uint256 remainder = totalAmount - fee;
+        uint256 fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
+        uint256 totalAmount = topupAmount + fee;
+        // Redirect the disbursement to this contract so we have the funds to topup and reserve the protocol fee
+        request.target = address(this);
+        request.amount = totalAmount;
+        bytes memory revisedRequest = abi.encode(request);
+
+        if (!budget_.disburse(revisedRequest)) {
+            revert BoostError.InvalidInitialization();
+        }
 
         bytes32 key = _generateKey(boostId, incentiveId);
         IncentiveDisbursalInfo storage info = incentivesFeeInfo[key];
         info.protocolFeesRemaining += fee;
 
-        if (remainder > 0) {
+        if (topupAmount > 0) {
             if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
-                // Approve exactly `remainder` tokens
+                // Approve exactly `topupAmount` tokens
                 IERC20 token = IERC20(request.asset);
-                token.approve(address(incentiveContract), remainder);
-                IToppable(address(incentiveContract)).topup(remainder);
+                token.approve(address(incentiveContract), topupAmount);
+                IToppable(address(incentiveContract)).topup(topupAmount);
                 token.approve(address(incentiveContract), 0);
             } else {
                 // ERC1155 => setApprovalForAll
                 IERC1155 erc1155 = IERC1155(request.asset);
                 erc1155.setApprovalForAll(address(incentiveContract), true);
-                IToppable(address(incentiveContract)).topup(remainder);
+                IToppable(address(incentiveContract)).topup(topupAmount);
                 erc1155.setApprovalForAll(address(incentiveContract), false);
             }
         }

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -206,8 +206,9 @@ contract BoostCore is Ownable, ReentrancyGuard {
     }
 
     /// @notice Top up an existing incentive using tokens from a budget.
-    ///         All tokens are first transferred into BoostCore, then fees are taken,
-    ///         and finally the remainder is topped up into the incentive.
+    ///         All tokens are first transferred into BoostCore, then a protocol fee
+    ///         is accounted for and reserved in this function. The remainder is approved
+    ///         and the incentive contract pulls the tokens during the topup call.
     /// @param boostId The ID of the Boost
     /// @param incentiveId The ID of the incentive within that Boost
     /// @param data_ The raw data to pass to the incentive’s `preflight` and eventually `topup`
@@ -225,6 +226,8 @@ contract BoostCore is Ownable, ReentrancyGuard {
         }
 
         ABudget.Transfer memory request = abi.decode(preflightData, (ABudget.Transfer));
+
+        // Redirect the disbursement to this contract so we have the funds to topup and reserve the protocol fee
         request.target = address(this);
         bytes memory revisedRequest = abi.encode(request);
 
@@ -247,12 +250,25 @@ contract BoostCore is Ownable, ReentrancyGuard {
 
         uint256 fee = (totalAmount * boost.protocolFee) / FEE_DENOMINATOR;
         uint256 remainder = totalAmount - fee;
+
         bytes32 key = _generateKey(boostId, incentiveId);
         IncentiveDisbursalInfo storage info = incentivesFeeInfo[key];
         info.protocolFeesRemaining += fee;
 
         if (remainder > 0) {
-            IToppable(address(incentiveContract)).topup(remainder);
+            if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
+                // Approve exactly `remainder` tokens
+                IERC20 token = IERC20(request.asset);
+                token.approve(address(incentiveContract), remainder);
+                IToppable(address(incentiveContract)).topup(remainder);
+                token.approve(address(incentiveContract), 0);
+            } else {
+                // ERC1155 => setApprovalForAll
+                IERC1155 erc1155 = IERC1155(request.asset);
+                erc1155.setApprovalForAll(address(incentiveContract), true);
+                IToppable(address(incentiveContract)).topup(remainder);
+                erc1155.setApprovalForAll(address(incentiveContract), false);
+            }
         }
     }
 

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -231,21 +231,28 @@ contract BoostCore is Ownable, ReentrancyGuard {
         _checkBudget(budget_);
 
         uint256 topupAmount;
+        uint256 fee;
+        uint256 totalAmount;
         if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
             ABudget.FungiblePayload memory payload = abi.decode(request.data, (ABudget.FungiblePayload));
             topupAmount = payload.amount;
+            fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
+            totalAmount = topupAmount + fee;
+            payload.amount = totalAmount;
+            request.data = abi.encode(payload);
         } else if (request.assetType == ABudget.AssetType.ERC1155) {
             ABudget.ERC1155Payload memory payload = abi.decode(request.data, (ABudget.ERC1155Payload));
             topupAmount = payload.amount;
+            fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
+            totalAmount = topupAmount + fee;
+            payload.amount = totalAmount;
+            request.data = abi.encode(payload);
         } else {
             revert BoostError.NotImplemented();
         }
 
-        uint256 fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
-        uint256 totalAmount = topupAmount + fee;
         // Redirect the disbursement to this contract so we have the funds to topup and reserve the protocol fee
         request.target = address(this);
-        request.amount = totalAmount;
         bytes memory revisedRequest = abi.encode(request);
 
         if (!budget_.disburse(revisedRequest)) {

--- a/packages/evm/contracts/budgets/ManagedBudgetWithFees.sol
+++ b/packages/evm/contracts/budgets/ManagedBudgetWithFees.sol
@@ -150,7 +150,7 @@ contract ManagedBudgetWithFees is AManagedBudgetWithFees, ManagedBudget {
                 revert InsufficientFunds(request.asset, avail, payload.amount + maxManagementFee);
             }
 
-            incentiveFeesMax[request.target] = maxManagementFee;
+            incentiveFeesMax[request.target] += maxManagementFee;
             reservedFunds[request.asset] += maxManagementFee;
             _distributedFungible[request.asset] += payload.amount;
             _transferFungible(request.asset, request.target, payload.amount);

--- a/packages/evm/contracts/budgets/ManagedBudgetWithFees.sol
+++ b/packages/evm/contracts/budgets/ManagedBudgetWithFees.sol
@@ -113,6 +113,20 @@ contract ManagedBudgetWithFees is AManagedBudgetWithFees, ManagedBudget {
         return (amount, asset);
     }
 
+    /// @notice A function that triggers a top-up on a specified incentive,
+    ///         using *this* budget contract as the source of funds.
+    /// @param boostId The ID of the Boost to top up
+    /// @param incentiveId The ID of the incentive within that Boost
+    /// @param data_ Arbitrary data forwarded to the incentive’s `preflight` and `topup`
+    function topupIncentive(address target, uint256 boostId, uint256 incentiveId, bytes calldata data_)
+        external
+        onlyAuthorized
+        returns (bool)
+    {
+        BoostCore(target).topupIncentiveFromBudget(boostId, incentiveId, data_, address(this));
+        return true;
+    }
+
     /// @inheritdoc ABudget
     /// @notice Disburses assets from the budget to a single recipient if sender is owner, admin, or manager
     /// @param data_ The packed {Transfer} request

--- a/packages/evm/contracts/incentives/ERC20PeggedVariableCriteriaIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20PeggedVariableCriteriaIncentive.sol
@@ -10,8 +10,9 @@ import {AERC20PeggedIncentive} from "contracts/incentives/AERC20PeggedIncentive.
 import {AIncentive} from "contracts/incentives/AIncentive.sol";
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {RBAC} from "contracts/shared/RBAC.sol";
+import {IToppable} from "contracts/shared/IToppable.sol";
 
-contract ERC20PeggedVariableCriteriaIncentive is RBAC, AERC20PeggedVariableCriteriaIncentive {
+contract ERC20PeggedVariableCriteriaIncentive is RBAC, AERC20PeggedVariableCriteriaIncentive, IToppable {
     using SafeTransferLib for address;
 
     event ERC20PeggedIncentiveInitialized(
@@ -153,6 +154,23 @@ contract ERC20PeggedVariableCriteriaIncentive is RBAC, AERC20PeggedVariableCrite
         emit Claimed(claim_.target, abi.encodePacked(asset, claim_.target, amount));
 
         return (amount, asset);
+    }
+
+    /// @notice Top up the incentive with more ERC20 tokens
+    /// @dev Uses `msg.sender` as the token source, and uses `asset` to identify which token.
+    ///      Caller must approve this contract to spend at least `amount` prior to calling.
+    /// @param amount The number of tokens to top up
+    function topup(uint256 amount) external virtual override onlyOwnerOrRoles(MANAGER_ROLE) {
+        if (amount == 0) {
+            revert BoostError.InvalidInitialization();
+        }
+        // Transfer tokens from the caller into this contract
+        asset.safeTransferFrom(msg.sender, address(this), amount);
+
+        // Increase the total incentive limit
+        limit += amount;
+
+        emit ToppedUp(msg.sender, amount);
     }
 
     /// @notice Check if an incentive is claimable

--- a/packages/evm/contracts/incentives/ERC20VariableCriteriaIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20VariableCriteriaIncentive.sol
@@ -9,6 +9,7 @@ import {AERC20VariableCriteriaIncentive} from "contracts/incentives/AERC20Variab
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {AIncentive} from "contracts/incentives/AIncentive.sol";
+import {IToppable} from "contracts/shared/IToppable.sol";
 
 enum SignatureType {
     FUNC,
@@ -87,5 +88,22 @@ contract ERC20VariableCriteriaIncentive is AERC20VariableCriteriaIncentive {
 
         emit Claimed(claimTarget, abi.encodePacked(asset, claimTarget, claimAmount));
         return true;
+    }
+
+    /// @notice Top up the incentive with more ERC20 tokens
+    /// @dev Uses `msg.sender` as the token source, and uses `asset` to identify which token.
+    ///      Caller must approve this contract to spend at least `amount` prior to calling.
+    /// @param amount The number of tokens to top up
+    function topup(uint256 amount) external virtual override onlyOwnerOrRoles(MANAGER_ROLE) {
+        if (amount == 0) {
+            revert BoostError.InvalidInitialization();
+        }
+        // Transfer tokens from the caller into this contract
+        asset.safeTransferFrom(msg.sender, address(this), amount);
+
+        // Increase the total incentive limit
+        limit += amount;
+
+        emit ToppedUp(msg.sender, amount);
     }
 }

--- a/packages/evm/contracts/shared/IToppable.sol
+++ b/packages/evm/contracts/shared/IToppable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+interface IToppable {
+    event ToppedUp(address sender, uint256 amount);
+    /**
+     * @notice Tops up the contract with the specified amount. Should modify all local variables accordingly.
+     * @param amount The amount to top up, in wei.
+     */
+
+    function topup(uint256 amount) external;
+}

--- a/packages/evm/hardhat_build.config.cjs
+++ b/packages/evm/hardhat_build.config.cjs
@@ -6,14 +6,12 @@ module.exports = {
   solidity: {
     settings: {
       evmVersion: 'cancun',
+      optimizer: {
+        enabled: true,
+        runs: 10_000,
+      },
     },
     version: '0.8.26',
-  },
-  compilerOptions: {
-    optimizer: {
-      enabled: true,
-      runs: 10_000,
-    },
   },
   paths: {
     cache: './cache_hh',

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -773,7 +773,7 @@ contract BoostCoreTest is Test {
     }
 
     function testFuzzTopUpAndClaimIncentive_ProtocolFeeTransfer(uint256 rewardAmount, uint64 additionalProtocolFee)
-        internal
+        public
     {
         uint160 claimant = uint160(makeAddr("claimant"));
         uint16 claimLimit = 100;

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -816,7 +816,7 @@ contract BoostCoreTest is Test {
 
         // Mint an ERC721 token to the claimant
 
-        for (uint160 tokenId = 1; tokenId < 102; tokenId++) {
+        for (uint160 tokenId = 1; tokenId < 201; tokenId++) {
             hoax(address(claimant + tokenId));
             mockERC721.mint{value: 0.1 ether}(address(this));
 
@@ -843,7 +843,7 @@ contract BoostCoreTest is Test {
             );
         }
 
-        //assertEq(0, mockERC20.balanceOf(address(boostCore)), "unclaimedFunds In boost core");
+        assertEq(0, mockERC20.balanceOf(address(boostCore)), "unclaimedFunds In boost core");
     }
 
     function _do_topup(uint256 amountToMint, uint256 claimLimit, uint256 rewardAmount) internal {

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -772,6 +772,108 @@ contract BoostCoreTest is Test {
         assertEq(0, mockERC20.balanceOf(address(boostCore)), "unclaimedFunds In boost core");
     }
 
+    function testFuzzTopUpAndClaimIncentive_ProtocolFeeTransfer(uint256 rewardAmount, uint64 additionalProtocolFee)
+        internal
+    {
+        uint160 claimant = uint160(makeAddr("claimant"));
+        uint16 claimLimit = 100;
+        additionalProtocolFee = uint64(bound(additionalProtocolFee, 0, 9_000));
+        rewardAmount = bound(rewardAmount, 10_000, (type(uint256).max >> 15) / claimLimit);
+        uint64 totalFee = uint64(boostCore.protocolFee()) + additionalProtocolFee;
+        uint256 amountToMint = (rewardAmount + rewardAmount * totalFee / boostCore.FEE_DENOMINATOR()) * claimLimit;
+        mockERC20.mint(address(this), amountToMint);
+        mockERC20.approve(address(budget), amountToMint);
+        budget.allocate(
+            abi.encode(
+                ABudget.Transfer({
+                    assetType: ABudget.AssetType.ERC20,
+                    asset: address(mockERC20),
+                    target: address(this),
+                    data: abi.encode(ABudget.FungiblePayload({amount: amountToMint}))
+                })
+            )
+        );
+        address feeReceiver = makeAddr("0xfee");
+        boostCore.setProtocolFeeReceiver(feeReceiver);
+
+        bytes memory createBoostCalldata =
+            _makeValidCreateCalldataWithVariableRewardAmount(1, rewardAmount, claimLimit, additionalProtocolFee);
+
+        // Create the boost
+        boostCore.createBoost(createBoostCalldata);
+
+        // Get the boost and incentive contract
+        BoostLib.Boost memory boost = boostCore.getBoost(0);
+        ERC20Incentive incentive = ERC20Incentive(address(boost.incentives[0]));
+
+        _do_topup(amountToMint, claimLimit, rewardAmount);
+
+        // Calculate expected fee
+        uint256 claimAmount = incentive.reward();
+        uint256 protocolFeePercentage = boost.protocolFee;
+
+        uint256 expectedFee = (claimAmount * protocolFeePercentage) / boostCore.FEE_DENOMINATOR();
+
+        // Mint an ERC721 token to the claimant
+
+        for (uint160 tokenId = 1; tokenId < 102; tokenId++) {
+            hoax(address(claimant + tokenId));
+            mockERC721.mint{value: 0.1 ether}(address(this));
+
+            // Record initial balances
+            uint256 initialFeeReceiverBalance = mockERC20.balanceOf(feeReceiver);
+
+            // Prepare claim data
+            bytes memory data = abi.encode(address(this), abi.encode(tokenId));
+
+            // Expect the fee ProtocolFeesCollected event
+            vm.expectEmit();
+            emit BoostCore.ProtocolFeesCollected(0, 0, expectedFee, feeReceiver);
+
+            // Perform claim
+            hoax(address(claimant + tokenId));
+            boostCore.claimIncentive(0, 0, address(0), data);
+
+            // Verify fee transfer
+            assertApproxEqAbs(
+                mockERC20.balanceOf(feeReceiver),
+                initialFeeReceiverBalance + expectedFee,
+                boostCore.DUST_THRESHOLD(),
+                "Protocol fee not transferred correctly"
+            );
+        }
+
+        //assertEq(0, mockERC20.balanceOf(address(boostCore)), "unclaimedFunds In boost core");
+    }
+
+    function _do_topup(uint256 amountToMint, uint256 claimLimit, uint256 rewardAmount) internal {
+        mockERC20.mint(address(this), amountToMint);
+        mockERC20.approve(address(budget), amountToMint);
+
+        budget.allocate(
+            abi.encode(
+                ABudget.Transfer({
+                    assetType: ABudget.AssetType.ERC20,
+                    asset: address(mockERC20),
+                    target: address(this),
+                    data: abi.encode(ABudget.FungiblePayload({amount: amountToMint}))
+                })
+            )
+        );
+
+        bytes memory topupCalldata = abi.encode(
+            ERC20Incentive.InitPayload({
+                asset: address(mockERC20),
+                strategy: AERC20Incentive.Strategy.POOL,
+                reward: rewardAmount,
+                limit: claimLimit,
+                manager: address(budget)
+            })
+        );
+
+        boostCore.topupIncentiveFromBudget(0, 0, topupCalldata, address(budget));
+    }
+
     function testClaimIncentive_ProtocolFeeTransfer() public {
         address feeReceiver = address(0xfee);
         boostCore.setProtocolFeeReceiver(feeReceiver);
@@ -1144,7 +1246,7 @@ contract BoostCoreTest is Test {
                         strategy: AERC20Incentive.Strategy.POOL,
                         reward: rewardAmount,
                         limit: limit,
-                        manager: address(boostCore)
+                        manager: address(budget)
                     })
                 )
             });

--- a/packages/evm/test/incentives/ERC20PeggedIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20PeggedIncentive.t.sol
@@ -170,6 +170,41 @@ contract ERC20PeggedIncentiveTest is Test {
         assertEq(incentive.getPeg(), address(pegAsset));
     }
 
+    ////////////////////////////////////////
+    // ERC20VariablePeggedIncentive.topup
+    ////////////////////////////////////////
+
+    function testTopup() public {
+        // Initialize with reward=1 ether, limit=5 ether.
+        // The contract will hold 100 ether from setUp().
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+        assertEq(incentive.limit(), 5 ether, "Initial limit should be 5 ether");
+
+        // Approve enough tokens so the incentive contract can pull them
+        mockAsset.mint(address(this), 100 ether);
+        mockAsset.approve(address(incentive), 100 ether);
+
+        // Top up an additional 5 ether
+        incentive.topup(5 ether);
+
+        // The limit should now be 10 ether
+        assertEq(incentive.limit(), 10 ether, "Limit should increase by 5 ether");
+
+        // The contract should now hold 105 ether total
+        assertEq(mockAsset.balanceOf(address(incentive)), 105 ether, "Contract balance should now be 105 ether");
+    }
+
+    function testTopup_ZeroAmount() public {
+        // Initialize with reward=1 ether, limit=5 ether
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, address(this));
+
+        // Attempt to top up 0 => revert with InvalidInitialization
+        mockAsset.mint(address(this), 100 ether);
+        mockAsset.approve(address(incentive), 100 ether);
+        vm.expectRevert(BoostError.InvalidInitialization.selector);
+        incentive.topup(0);
+    }
+
     //////////////////////////////////////////////////
     // ERC20PeggedIncentive.getComponentInterface //
     //////////////////////////////////////////////////

--- a/packages/evm/test/incentives/ERC20PeggedVariableCriteriaIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20PeggedVariableCriteriaIncentive.t.sol
@@ -237,6 +237,42 @@ contract ERC20PeggedVariableCriteriaIncentiveTest is Test {
         assertEq(incentive.getPeg(), address(pegAsset));
     }
 
+    ////////////////////////////////////////////////
+    // ERC20PeggedVariableCriteriaIncentive.topup
+    ////////////////////////////////////////////////
+
+    function testTopup() public {
+        // Initialize with reward=1 ether, limit=5 ether.
+        // The contract will hold 100 ether from setUp().
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, 2 ether, address(this));
+        assertEq(incentive.limit(), 5 ether, "Initial limit should be 5 ether");
+
+        // Approve enough tokens so the incentive contract can pull them
+        mockAsset.mint(address(this), 100 ether);
+        mockAsset.approve(address(incentive), 100 ether);
+
+        // Top up an additional 5 ether
+        incentive.topup(5 ether);
+
+        // The limit should now be 10 ether
+        assertEq(incentive.limit(), 10 ether, "Limit should increase by 5 ether");
+
+        // The contract should now hold 105 ether total
+        assertEq(mockAsset.balanceOf(address(incentive)), 105 ether, "Contract balance should now be 105 ether");
+    }
+
+    function testTopup_ZeroAmount() public {
+        // Initialize with reward=1 ether, limit=5 ether
+        _initialize(address(mockAsset), address(pegAsset), 1 ether, 5 ether, 2 ether, address(this));
+
+        // Attempt to top up 0 => revert with InvalidInitialization
+        mockAsset.mint(address(this), 100 ether);
+
+        mockAsset.approve(address(incentive), 100 ether);
+        vm.expectRevert(BoostError.InvalidInitialization.selector);
+        incentive.topup(0);
+    }
+
     //////////////////////////////////////////////////////////////
     // ERC20PeggedVariableCriteriaIncentive.getComponentInterface
     //////////////////////////////////////////////////////////////

--- a/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
@@ -163,6 +163,41 @@ contract ERC20VariableIncentiveTest is Test {
         assertEq(incentive.limit(), 3 ether);
     }
 
+    ////////////////////////////////
+    // ERC20VariableIncentive.topup
+    ////////////////////////////////
+
+    function testTopup() public {
+        // Initialize with reward=1 ether, limit=5 ether.
+        // The contract will hold 100 ether from setUp().
+        _initialize(address(mockAsset), 1 ether, 5 ether);
+        assertEq(incentive.limit(), 5 ether, "Initial limit should be 5 ether");
+
+        // Approve enough tokens so the incentive contract can pull them
+        mockAsset.mint(address(this), 100 ether);
+        mockAsset.approve(address(incentive), 100 ether);
+
+        // Top up an additional 5 ether
+        incentive.topup(5 ether);
+
+        // The limit should now be 10 ether
+        assertEq(incentive.limit(), 10 ether, "Limit should increase by 5 ether");
+
+        // The contract should now hold 105 ether total
+        assertEq(mockAsset.balanceOf(address(incentive)), 105 ether, "Contract balance should now be 105 ether");
+    }
+
+    function testTopup_ZeroAmount() public {
+        // Initialize with reward=1 ether, limit=5 ether
+        _initialize(address(mockAsset), 1 ether, 5 ether);
+
+        // Attempt to top up 0 => revert with InvalidInitialization
+        mockAsset.mint(address(this), 100 ether);
+        mockAsset.approve(address(incentive), 100 ether);
+        vm.expectRevert(BoostError.InvalidInitialization.selector);
+        incentive.topup(0);
+    }
+
     //////////////////////////////////////////////////
     // ERC20VariableIncentive.getComponentInterface //
     //////////////////////////////////////////////////

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -1690,9 +1690,12 @@ export class BoostCore extends Deployable<
       throw new Error(`Incentive with ID ${incentiveId} not found`);
     }
 
-    const incentiveData = incentive.getTopupPayload(topupAmount);
+    const incentiveData = await incentive.getTopupPayload(topupAmount);
 
-    // 6. Call raw method with the full total
+    if (!(topupAmount > 0)) {
+      throw new Error('Top-up amount must be greater than zero');
+    }
+
     return await this.topupIncentiveFromBudgetRaw(
       boostId,
       incentiveId,
@@ -1763,7 +1766,11 @@ export class BoostCore extends Deployable<
       throw new Error(`Incentive with ID ${incentiveId} not found`);
     }
 
-    const incentiveData = incentive.getTopupPayload(topupAmount);
+    if (!(topupAmount > 0)) {
+      throw new Error('Top-up amount must be greater than zero');
+    }
+
+    const incentiveData = await incentive.getTopupPayload(topupAmount);
 
     return await this.topupIncentiveFromSenderRaw(
       boostId,
@@ -1819,7 +1826,7 @@ export class BoostCore extends Deployable<
   private async topupIncentiveFromSenderRaw(
     boostId: bigint,
     incentiveId: bigint,
-    preflightData: `0x${string}`,
+    preflightData: Hex,
     params?: WriteParams,
   ) {
     const { request, result } = await simulateBoostCoreTopupIncentiveFromSender(
@@ -1854,7 +1861,7 @@ export class BoostCore extends Deployable<
   private async topupIncentiveFromBudgetRaw(
     boostId: bigint,
     incentiveId: bigint,
-    preflightData: `0x${string}`,
+    preflightData: Hex,
     budget?: Address,
     params?: WriteParams,
   ) {

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -1763,7 +1763,7 @@ export class BoostCore extends Deployable<
       throw new Error(`Incentive with ID ${incentiveId} not found`);
     }
 
-    const incentiveData = incentive.getTopupPayload(topupAmount, params);
+    const incentiveData = incentive.getTopupPayload(topupAmount);
 
     return await this.topupIncentiveFromSenderRaw(
       boostId,

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -331,6 +331,23 @@ export class AllowListIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the AllowListIncentive contract.
+   *
+   * @public
+   * @param {bigint} netAmount The net number of slots to be added to the allowlist.
+   * @returns {Hex} The ABI-encoded top-up payload.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'address', name: 'allowList' },
+        { type: 'uint256', name: 'limit' },
+      ],
+      [this.payload?.allowList ?? zeroHash, netAmount],
+    );
+  }
+
+  /**
    * Builds the claim data for the AllowListIncentive.
    *
    * @public

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -492,7 +492,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {bigint} netAmount The additional tokens to add to `totalBudget`.
    * @returns {Hex} The ABI-encoded, updated CGDAIncentive payload.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return encodeAbiParameters(
       [
         { type: 'address', name: 'asset' },
@@ -503,7 +503,7 @@ export class CGDAIncentive extends DeployableTarget<
         { type: 'address', name: 'manager' },
       ],
       [
-        this.payload?.asset ?? zeroHash,
+        (await this.asset()) ?? zeroHash,
         this.payload?.initialReward ?? 0n,
         this.payload?.rewardDecay ?? 0n,
         this.payload?.rewardBoost ?? 0n,

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -483,6 +483,37 @@ export class CGDAIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the CGDAIncentive contract.
+   *
+   * In this approach, we treat a "top-up" as incrementing the existing `totalBudget`
+   * in the incentive by `netAmount`. The entire payload is re-encoded with the updated budget.
+   *
+   * @public
+   * @param {bigint} netAmount The additional tokens to add to `totalBudget`.
+   * @returns {Hex} The ABI-encoded, updated CGDAIncentive payload.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'address', name: 'asset' },
+        { type: 'uint256', name: 'initialReward' },
+        { type: 'uint256', name: 'rewardDecay' },
+        { type: 'uint256', name: 'rewardBoost' },
+        { type: 'uint256', name: 'totalBudget' },
+        { type: 'address', name: 'manager' },
+      ],
+      [
+        this.payload?.asset ?? zeroHash,
+        this.payload?.initialReward ?? 0n,
+        this.payload?.rewardDecay ?? 0n,
+        this.payload?.rewardBoost ?? 0n,
+        netAmount,
+        this.payload?.manager ?? zeroHash,
+      ],
+    );
+  }
+
+  /**
    * Builds the claim data for the CGDAIncentive.
    *
    * @public

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -503,6 +503,32 @@ export class ERC20Incentive extends DeployableTarget<
   }
 
   /**
+   * A helper that composes a typed "top-up" parameter object
+   * given a net top-up amount. You can name it whatever you like
+   * (e.g. topupParamsFromNetAmount, getTopupPayload, etc.).
+   *
+   * @public
+   * @param {bigint} netAmount The net top-up tokens the user wants to add
+   * @param {?WriteParams} [params] (optional) if you need them
+   * @returns {Hex} the ABI-encoded data for top-up
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    // 1. Build a typed object matching your `ERC20IncentivePayload`.
+    //    For example, you might want to increment `limit` by `netAmount`,
+    //    or set `reward = netAmount`. That’s up to your logic:
+    const typed: ERC20IncentivePayload = {
+      asset: this.payload?.asset || zeroAddress,
+      strategy: this.payload?.strategy || StrategyType.POOL, // e.g. StrategyType.POOL
+      reward: netAmount, // store net top-up as the "reward"
+      limit: 1n, // or maybe add netAmount to existing limit
+      manager: this.payload?.manager || zeroAddress,
+    };
+
+    // 2. Encode it with your existing `prepareERC20IncentivePayload(...)`.
+    return prepareERC20IncentivePayload(typed);
+  }
+
+  /**
    * Builds the claim data for the ERC20Incentive.
    *
    * @public

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -512,15 +512,16 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params] (optional) if you need them
    * @returns {Hex} the ABI-encoded data for top-up
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     // 1. Build a typed object matching your `ERC20IncentivePayload`.
     //    For example, you might want to increment `limit` by `netAmount`,
     //    or set `reward = netAmount`. That’s up to your logic:
+    const asset = await this.asset();
     const typed: ERC20IncentivePayload = {
-      asset: this.payload?.asset || zeroAddress,
-      strategy: this.payload?.strategy || StrategyType.POOL, // e.g. StrategyType.POOL
-      reward: netAmount, // store net top-up as the "reward"
-      limit: 1n, // or maybe add netAmount to existing limit
+      asset: asset || zeroAddress,
+      strategy: StrategyType.POOL, // e.g. StrategyType.POOL
+      reward: 1n, // store net top-up as the "reward"
+      limit: netAmount, // or maybe add netAmount to existing limit
       manager: this.payload?.manager || zeroAddress,
     };
 

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -478,6 +478,24 @@ export class ERC20PeggedIncentive extends DeployableTarget<
       [rewardAmount],
     );
   }
+  /**
+   * Generates a top-up payload for the ERC20PeggedIncentive contract by incrementing
+   * the existing `limit` field by `netAmount`. The entire payload is then re-encoded
+   * via `prepareERC20PeggedIncentivePayload(...)`.
+   *
+   * @public
+   * @param {bigint} netAmount - The additional limit to add to this incentive.
+   * @returns {Hex} The ABI-encoded payload with the updated `limit`.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return prepareERC20PeggedIncentivePayload({
+      asset: this.payload?.asset ?? zeroAddress,
+      peg: this.payload?.peg ?? zeroAddress,
+      reward: this.payload?.reward ?? 0n,
+      limit: netAmount,
+      manager: this.payload?.manager ?? zeroAddress,
+    });
+  }
 
   /**
    * Decodes claim data for the ERC20PeggedIncentive, returning the claim amount.

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -487,9 +487,9 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    * @param {bigint} netAmount - The additional limit to add to this incentive.
    * @returns {Hex} The ABI-encoded payload with the updated `limit`.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return prepareERC20PeggedIncentivePayload({
-      asset: this.payload?.asset ?? zeroAddress,
+      asset: (await this.asset()) ?? zeroAddress,
       peg: this.payload?.peg ?? zeroAddress,
       reward: this.payload?.reward ?? 0n,
       limit: netAmount,

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -622,9 +622,9 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
    * @param {bigint} netAmount - The additional limit to add to this incentive.
    * @returns {Hex} The ABI-encoded payload with the updated `limit`.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return prepareERC20PeggedVariableCriteriaIncentivePayload({
-      asset: this.payload?.asset ?? zeroAddress,
+      asset: (await this.asset()) ?? zeroAddress,
       peg: this.payload?.peg ?? zeroAddress,
       reward: this.payload?.reward ?? 0n,
       limit: netAmount,

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -614,6 +614,32 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the ERC20PeggedIncentive contract by incrementing
+   * the existing `limit` field by `netAmount`. The entire payload is then re-encoded
+   * via `prepareERC20PeggedIncentivePayload(...)`.
+   *
+   * @public
+   * @param {bigint} netAmount - The additional limit to add to this incentive.
+   * @returns {Hex} The ABI-encoded payload with the updated `limit`.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return prepareERC20PeggedVariableCriteriaIncentivePayload({
+      asset: this.payload?.asset ?? zeroAddress,
+      peg: this.payload?.peg ?? zeroAddress,
+      reward: this.payload?.reward ?? 0n,
+      limit: netAmount,
+      maxReward: this.payload?.maxReward ?? 0n,
+      manager: this.payload?.manager ?? zeroAddress,
+      criteria: this.payload?.criteria ?? {
+        criteriaType: 0,
+        signature: zeroAddress,
+        fieldIndex: 0,
+        targetContract: zeroAddress,
+      },
+    });
+  }
+
+  /**
    * @inheritdoc
    *
    * @public

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -404,12 +404,12 @@ export class ERC20VariableIncentive<
    * @param {bigint} netAmount - The additional limit to add to this incentive.
    * @returns {Hex} The ABI-encoded payload with the updated `limit`.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return prepareERC20VariableIncentivePayload({
-      asset: zeroAddress,
-      reward: 0n,
+      asset: (await this.asset()) as Address,
+      reward: netAmount,
       manager: zeroAddress,
-      limit: netAmount,
+      limit: 1n,
     });
   }
 

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -22,6 +22,7 @@ import {
   type Hex,
   decodeAbiParameters,
   encodeAbiParameters,
+  zeroAddress,
 } from 'viem';
 import { ERC20VariableIncentive as ERC20VariableIncentiveBases } from '../../dist/deployments.json';
 import type {
@@ -393,6 +394,23 @@ export class ERC20VariableIncentive<
       this.limit(params),
     ]);
     return limit - totalClaimed;
+  }
+  /**
+   * Generates a top-up payload for the ERC20PeggedIncentive contract by incrementing
+   * the existing `limit` field by `netAmount`. The entire payload is then re-encoded
+   * via `prepareERC20PeggedIncentivePayload(...)`.
+   *
+   * @public
+   * @param {bigint} netAmount - The additional limit to add to this incentive.
+   * @returns {Hex} The ABI-encoded payload with the updated `limit`.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return prepareERC20VariableIncentivePayload({
+      asset: zeroAddress,
+      reward: 0n,
+      manager: zeroAddress,
+      limit: netAmount,
+    });
   }
 
   /**

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -349,6 +349,28 @@ export class PointsIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the PointsIncentive contract.
+   *
+   * @public
+   * @param {bigint} netAmount The net reward amount to be added to the incentive.
+   * @returns {Hex} The ABI-encoded top-up payload.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'address', name: 'venue' },
+        { type: 'bytes4', name: 'selector' },
+        { type: 'uint256', name: 'amount' },
+      ],
+      [
+        this.payload?.venue ?? zeroHash,
+        this.payload?.selector ?? zeroHash,
+        netAmount,
+      ],
+    );
+  }
+
+  /**
    * Builds the claim data for the PointsIncentive.
    *
    * @public


### PR DESCRIPTION
### Description
This PR introduces a new top-up flow in `BoostCore` that routes additional tokens into existing incentives, adding `topupIncentiveFromBudget` (for budget-based tokens) and `topupIncentiveFromSender` (for user-supplied tokens). Both flows gather all tokens in `BoostCore` , compute and record protocol fees, and temporarily approve the incentive contract to pull the remainder via its `topup` function. We remove approval after the transfers. Two things to watch out for in review are that funds can't be pulled out of core if there _was_ a malicious incentive and that all permissions on the budget are respected. Basically we want to avoid loss of funds.

**Assumptions**:  
- If sending directly the user has already approved `BoostCore` for ERC20 tokens or setApprovalForAll for ERC1155 tokens .
- If sending from a budget the user must be permissioned on the budget. Approval isn't needed based on how we handle disbursals.  
- The `bytes data_` argument decodes based on the incentives `InitPayload` struct an example of which is shown below.  
- Protocol fees are *only* reserved in `BoostCore`, and may be transferred or settled at a later time.  

**New Function Signatures**  
```solidity
function topupIncentiveFromBudget(
    uint256 boostId,
    uint256 incentiveId,
    bytes calldata data_,
    address budget
) external nonReentrant;

function topupIncentiveFromSender(
    uint256 boostId,
    uint256 incentiveId,
    bytes calldata data_
) external nonReentrant;
```

**Example of Relevant Struct for `_data` payload**  
```solidity
struct InitPayload {
        address asset;
        Strategy strategy;
        uint256 reward;
        uint256 limit;
        address manager;
    }
```
This param (`_data`) should be the InitPayload for the incentive being topped up.

