### PR TITLE
[BOOST-5215] feat(evm): uint vs int handling in event action

### DIFF
--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -34,7 +34,8 @@ abstract contract AEventAction is AAction {
         ADDRESS,
         BYTES,
         STRING,
-        TUPLE
+        TUPLE,
+        INT
     }
 
     // Define Structs


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
Fairly straightforward. Adds the primitive type into the `EventAction` and then makes the corresponding changes in the SDK. We're also going to need to make changes in the application to handle int values on ABIs. Another thing to consider is that `int`/`uint` values less than 256 should also probably be supported. This only gets gnarly when it's a uint value smaller than `bigInt` which I believe is around uint64? 
💔 Thank you!
