### PR TITLE
[BOOST-5217] feat(evm): only trigger dust hatch if there is a value amount

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -595,7 +595,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
     // helper that transfers dust to protocolFeeReceiver
     function _dustHatch(address asset) internal {
         uint256 balance = IERC20(asset).balanceOf(address(this));
-        if (balance < DUST_THRESHOLD) {
+        if (balance > 0 && balance < DUST_THRESHOLD) {
             asset.safeTransfer(protocolFeeReceiver, balance);
         }
     }


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
Super simple fix so that we can support tokens that don't allow for transfers of amount zero (💩 )

💔 Thank you!
