### PR TITLE
[BOOST-5221] feat(sdk): update tuple support helpers to add terminators

### DIFF
--- a/.changeset/breezy-jokes-judge.md
+++ b/.changeset/breezy-jokes-judge.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+[BOOST-5221] feat(sdk): update tuple support helpers to add terminators

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1241,6 +1241,15 @@ describe("Tuple & bitpacked fieldIndex support", () => {
       expect(result).toEqual(resultIndexes);
     });
 
+    test("packs 3 indexes with the automatic addition of a terminator and unpacks them correctly", () => {
+      const indexes = [0, 3, 5]; // sample indexes
+      const packed = packFieldIndexes(indexes);
+      const result = unpackFieldIndexes(packed);
+      const resultIndexes = [0, 3, 5]; // should terminate on it's own even if a terminator isn't passed in
+
+      expect(result).toEqual(resultIndexes);
+    });
+
     test("throws if more than five indexes are provided", () => {
       expect(() => packFieldIndexes([1, 2, 3, 4, 5, 6])).toThrowError(
         "Can only pack up to 5 indexes.",

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1611,6 +1611,9 @@ export function packFieldIndexes(indexes: number[]): number {
     }
     packed |= (index & MAX_FIELD_INDEX) << (i * 6); // Each index occupies 6 bits
   });
+  if (indexes.length < 5) {
+    packed |= MAX_FIELD_INDEX << (indexes.length * 6); // Terminator
+  }
 
   return packed;
 }


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/boostxyz/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
The usage of terminators was confusing for integrators so now we automatically add a terminator so users of the SDK don't need to understand how the field index packing works as well. Now when an array of less than five is packed into the packing function we just automatically append a terminator so that the underlying data structure doesn't need to be understood at all at the application level.
💔 Thank you!
