### PR TITLE
[ADHOC] fix: prevent transfer abi mutation

### DIFF
--- a/.changeset/smart-falcons-joke.md
+++ b/.changeset/smart-falcons-joke.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+prevent mutatation of Transfer abi be using structuredClone

--- a/.changeset/smart-falcons-joke.md
+++ b/.changeset/smart-falcons-joke.md
@@ -2,4 +2,4 @@
 "@boostxyz/sdk": patch
 ---
 
-prevent mutatation of Transfer abi be using structuredClone
+prevent mutatation of Transfer abi by using structuredClone

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -829,9 +829,9 @@ export class EventAction extends DeployableTarget<
     const filteredLogs = receipt.logs.filter(
       (log) => log.topics[0] === TRANSFER_SIGNATURE,
     );
-    const event = abi[
-      'Transfer(address indexed,address indexed,uint256 indexed)'
-    ] as AbiEvent;
+    const event = structuredClone(
+      abi['Transfer(address indexed,address indexed,uint256 indexed)'],
+    ) as AbiEvent;
 
     // ERC721
     try {


### PR DESCRIPTION
### Description
- uses a deepclone of the Transfer abi to prevent upstream mutations

https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone

