### PR TITLE
[BOOST-5213] [SDK] allow for 4byte signatures without padding

### DIFF
--- a/.changeset/proud-pianos-pretend.md
+++ b/.changeset/proud-pianos-pretend.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+add padding to 4-byte function selectors in signature

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -26,6 +26,7 @@ import {
   fromHex,
   isAddress,
   isAddressEqual,
+  pad,
   toEventSelector,
   zeroAddress,
   zeroHash,
@@ -1504,19 +1505,31 @@ export function prepareEventActionPayload({
       {
         actionClaimant: _toRawActionStep(actionClaimant),
         actionStepOne: {
-          ..._toRawActionStep(actionStepOne),
+          ..._toRawActionStep({
+            ...actionStepOne,
+            signature: pad(actionStepOne.signature),
+          }),
           actionType: actionStepOne.actionType || 0,
         },
         actionStepTwo: {
-          ..._toRawActionStep(actionStepTwo),
+          ..._toRawActionStep({
+            ...actionStepTwo,
+            signature: pad(actionStepTwo.signature),
+          }),
           actionType: actionStepTwo.actionType || 0,
         },
         actionStepThree: {
-          ..._toRawActionStep(actionStepThree),
+          ..._toRawActionStep({
+            ...actionStepThree,
+            signature: pad(actionStepThree.signature),
+          }),
           actionType: actionStepThree.actionType || 0,
         },
         actionStepFour: {
-          ..._toRawActionStep(actionStepFour),
+          ..._toRawActionStep({
+            ...actionStepFour,
+            signature: pad(actionStepFour.signature),
+          }),
           actionType: actionStepFour.actionType || 0,
         },
       },

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1503,7 +1503,10 @@ export function prepareEventActionPayload({
     ],
     [
       {
-        actionClaimant: _toRawActionStep(actionClaimant),
+        actionClaimant: {
+          ..._toRawActionStep(actionClaimant),
+          signature: pad(actionClaimant.signature),
+        },
         actionStepOne: {
           ..._toRawActionStep({
             ...actionStepOne,


### PR DESCRIPTION
### Description
- allows use of a 4-byte function selector as a signature when setting up action steps in boost creation using SDK.
- all signatures will be left padded to 32-bytes
- tested locally in SDK playground using pnpm link

https://linear.app/rh-app/issue/BOOST-5213/[sdk]-allow-for-4byte-signatures-without-padding
