### PR TITLE
[BOOST-5243] [SDK] derive signatureType from selector in eventAction

### DIFF
--- a/.changeset/tame-bikes-run.md
+++ b/.changeset/tame-bikes-run.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+derive signatureType from signature

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1366,6 +1366,18 @@ function _fromRawActionStep<T extends RawActionStep | RawActionClaimant>(
 }
 
 /**
+ * Typeguard to determine if a user is supplying a simple or raw EventActionPayload
+ *
+ * @param {*} opts
+ * @returns {opts is EventActionPayloadSimple}
+ */
+function _isEventActionPayloadSimple(
+  opts: EventActionPayload,
+): opts is EventActionPayloadSimple {
+  return Array.isArray((opts as EventActionPayloadSimple).actionSteps);
+}
+
+/**
  * Determines whether a signature is an event or function signature based on its format.
  * - 32-byte signatures (0x + 64 chars) that don't start with 28 zeros are event signatures
  * - 4-byte signatures (0x + 8 chars) or 32-byte signatures with 28 leading zeros are function signatures

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1389,12 +1389,12 @@ function _isEventActionPayloadSimple(
 export function detectSignatureType(signature: Hex): SignatureType {
   const hexWithoutPrefix = signature.slice(2);
 
-  // 4-byte function selector (8 hex chars)
+  // 4-byte function selectors (8 hex chars)
   if (hexWithoutPrefix.length === 8) {
     return SignatureType.FUNC;
   }
 
-  // I32-byte selectors (64 hex chars)
+  // 32-byte selectors (64 hex chars)
   if (hexWithoutPrefix.length === 64) {
     // Check if it starts with 28 bytes (56 chars) of zeros
     const leadingPart = hexWithoutPrefix.slice(0, 56);


### PR DESCRIPTION
### Description
- makes the signatureType optional in the eventAction creation.
- derives the signatureType based on the signature used

https://linear.app/rh-app/issue/BOOST-5243/derive-signature-type-from-selector


