### PR TITLE
[BOOST-5225] feat(sdk): add topup helpers to SDK

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -268,6 +268,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
         uint256 topupAmount;
         uint256 fee;
         uint256 totalAmount;
+        uint256 tokenId;
         if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
             ABudget.FungiblePayload memory payload = abi.decode(request.data, (ABudget.FungiblePayload));
             topupAmount = payload.amount;
@@ -280,6 +281,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
             fee = (topupAmount * boost.protocolFee) / FEE_DENOMINATOR;
             totalAmount = topupAmount + fee;
             payload.amount = totalAmount;
+            tokenId = payload.tokenId;
         } else {
             revert BoostError.NotImplemented();
         }
@@ -292,18 +294,20 @@ contract BoostCore is Ownable, ReentrancyGuard {
         }
 
         if (topupAmount > 0) {
-            {
-                if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
-                    IERC20 token = IERC20(request.asset);
-                    token.approve(address(incentiveContract), topupAmount);
-                    IToppable(address(incentiveContract)).topup(topupAmount);
-                    token.approve(address(incentiveContract), 0);
-                } else {
-                    IERC1155 erc1155 = IERC1155(request.asset);
-                    erc1155.setApprovalForAll(address(incentiveContract), true);
-                    IToppable(address(incentiveContract)).topup(topupAmount);
-                    erc1155.setApprovalForAll(address(incentiveContract), false);
-                }
+            if (request.assetType == ABudget.AssetType.ERC20 || request.assetType == ABudget.AssetType.ETH) {
+                // Approve exactly `topupAmount` tokens
+                IERC20 token = IERC20(request.asset);
+                token.transferFrom(msg.sender, address(this), totalAmount);
+                token.approve(address(incentiveContract), topupAmount);
+                IToppable(address(incentiveContract)).topup(topupAmount);
+                token.approve(address(incentiveContract), 0);
+            } else {
+                // ERC1155 => setApprovalForAll
+                IERC1155 erc1155 = IERC1155(request.asset);
+                erc1155.safeTransferFrom(msg.sender, address(this), tokenId, totalAmount, "");
+                erc1155.setApprovalForAll(address(incentiveContract), true);
+                IToppable(address(incentiveContract)).topup(topupAmount);
+                erc1155.setApprovalForAll(address(incentiveContract), false);
             }
             emit BoostToppedUp(boostId, incentiveId, msg.sender, topupAmount, fee);
         }

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -1690,9 +1690,12 @@ export class BoostCore extends Deployable<
       throw new Error(`Incentive with ID ${incentiveId} not found`);
     }
 
-    const incentiveData = incentive.getTopupPayload(topupAmount);
+    const incentiveData = await incentive.getTopupPayload(topupAmount);
 
-    // 6. Call raw method with the full total
+    if (!(topupAmount > 0)) {
+      throw new Error('Top-up amount must be greater than zero');
+    }
+
     return await this.topupIncentiveFromBudgetRaw(
       boostId,
       incentiveId,
@@ -1763,7 +1766,11 @@ export class BoostCore extends Deployable<
       throw new Error(`Incentive with ID ${incentiveId} not found`);
     }
 
-    const incentiveData = incentive.getTopupPayload(topupAmount);
+    if (!(topupAmount > 0)) {
+      throw new Error('Top-up amount must be greater than zero');
+    }
+
+    const incentiveData = await incentive.getTopupPayload(topupAmount);
 
     return await this.topupIncentiveFromSenderRaw(
       boostId,
@@ -1819,7 +1826,7 @@ export class BoostCore extends Deployable<
   private async topupIncentiveFromSenderRaw(
     boostId: bigint,
     incentiveId: bigint,
-    preflightData: `0x${string}`,
+    preflightData: Hex,
     params?: WriteParams,
   ) {
     const { request, result } = await simulateBoostCoreTopupIncentiveFromSender(
@@ -1854,7 +1861,7 @@ export class BoostCore extends Deployable<
   private async topupIncentiveFromBudgetRaw(
     boostId: bigint,
     incentiveId: bigint,
-    preflightData: `0x${string}`,
+    preflightData: Hex,
     budget?: Address,
     params?: WriteParams,
   ) {

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -1763,7 +1763,7 @@ export class BoostCore extends Deployable<
       throw new Error(`Incentive with ID ${incentiveId} not found`);
     }
 
-    const incentiveData = incentive.getTopupPayload(topupAmount, params);
+    const incentiveData = incentive.getTopupPayload(topupAmount);
 
     return await this.topupIncentiveFromSenderRaw(
       boostId,

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -331,6 +331,23 @@ export class AllowListIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the AllowListIncentive contract.
+   *
+   * @public
+   * @param {bigint} netAmount The net number of slots to be added to the allowlist.
+   * @returns {Hex} The ABI-encoded top-up payload.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'address', name: 'allowList' },
+        { type: 'uint256', name: 'limit' },
+      ],
+      [this.payload?.allowList ?? zeroHash, netAmount],
+    );
+  }
+
+  /**
    * Builds the claim data for the AllowListIncentive.
    *
    * @public

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -492,7 +492,7 @@ export class CGDAIncentive extends DeployableTarget<
    * @param {bigint} netAmount The additional tokens to add to `totalBudget`.
    * @returns {Hex} The ABI-encoded, updated CGDAIncentive payload.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return encodeAbiParameters(
       [
         { type: 'address', name: 'asset' },
@@ -503,7 +503,7 @@ export class CGDAIncentive extends DeployableTarget<
         { type: 'address', name: 'manager' },
       ],
       [
-        this.payload?.asset ?? zeroHash,
+        (await this.asset()) ?? zeroHash,
         this.payload?.initialReward ?? 0n,
         this.payload?.rewardDecay ?? 0n,
         this.payload?.rewardBoost ?? 0n,

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -483,6 +483,37 @@ export class CGDAIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the CGDAIncentive contract.
+   *
+   * In this approach, we treat a "top-up" as incrementing the existing `totalBudget`
+   * in the incentive by `netAmount`. The entire payload is re-encoded with the updated budget.
+   *
+   * @public
+   * @param {bigint} netAmount The additional tokens to add to `totalBudget`.
+   * @returns {Hex} The ABI-encoded, updated CGDAIncentive payload.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'address', name: 'asset' },
+        { type: 'uint256', name: 'initialReward' },
+        { type: 'uint256', name: 'rewardDecay' },
+        { type: 'uint256', name: 'rewardBoost' },
+        { type: 'uint256', name: 'totalBudget' },
+        { type: 'address', name: 'manager' },
+      ],
+      [
+        this.payload?.asset ?? zeroHash,
+        this.payload?.initialReward ?? 0n,
+        this.payload?.rewardDecay ?? 0n,
+        this.payload?.rewardBoost ?? 0n,
+        netAmount,
+        this.payload?.manager ?? zeroHash,
+      ],
+    );
+  }
+
+  /**
    * Builds the claim data for the CGDAIncentive.
    *
    * @public

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -503,6 +503,32 @@ export class ERC20Incentive extends DeployableTarget<
   }
 
   /**
+   * A helper that composes a typed "top-up" parameter object
+   * given a net top-up amount. You can name it whatever you like
+   * (e.g. topupParamsFromNetAmount, getTopupPayload, etc.).
+   *
+   * @public
+   * @param {bigint} netAmount The net top-up tokens the user wants to add
+   * @param {?WriteParams} [params] (optional) if you need them
+   * @returns {Hex} the ABI-encoded data for top-up
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    // 1. Build a typed object matching your `ERC20IncentivePayload`.
+    //    For example, you might want to increment `limit` by `netAmount`,
+    //    or set `reward = netAmount`. That’s up to your logic:
+    const typed: ERC20IncentivePayload = {
+      asset: this.payload?.asset || zeroAddress,
+      strategy: this.payload?.strategy || StrategyType.POOL, // e.g. StrategyType.POOL
+      reward: netAmount, // store net top-up as the "reward"
+      limit: 1n, // or maybe add netAmount to existing limit
+      manager: this.payload?.manager || zeroAddress,
+    };
+
+    // 2. Encode it with your existing `prepareERC20IncentivePayload(...)`.
+    return prepareERC20IncentivePayload(typed);
+  }
+
+  /**
    * Builds the claim data for the ERC20Incentive.
    *
    * @public

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -512,15 +512,16 @@ export class ERC20Incentive extends DeployableTarget<
    * @param {?WriteParams} [params] (optional) if you need them
    * @returns {Hex} the ABI-encoded data for top-up
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     // 1. Build a typed object matching your `ERC20IncentivePayload`.
     //    For example, you might want to increment `limit` by `netAmount`,
     //    or set `reward = netAmount`. That’s up to your logic:
+    const asset = await this.asset();
     const typed: ERC20IncentivePayload = {
-      asset: this.payload?.asset || zeroAddress,
-      strategy: this.payload?.strategy || StrategyType.POOL, // e.g. StrategyType.POOL
-      reward: netAmount, // store net top-up as the "reward"
-      limit: 1n, // or maybe add netAmount to existing limit
+      asset: asset || zeroAddress,
+      strategy: StrategyType.POOL, // e.g. StrategyType.POOL
+      reward: 1n, // store net top-up as the "reward"
+      limit: netAmount, // or maybe add netAmount to existing limit
       manager: this.payload?.manager || zeroAddress,
     };
 

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -478,6 +478,24 @@ export class ERC20PeggedIncentive extends DeployableTarget<
       [rewardAmount],
     );
   }
+  /**
+   * Generates a top-up payload for the ERC20PeggedIncentive contract by incrementing
+   * the existing `limit` field by `netAmount`. The entire payload is then re-encoded
+   * via `prepareERC20PeggedIncentivePayload(...)`.
+   *
+   * @public
+   * @param {bigint} netAmount - The additional limit to add to this incentive.
+   * @returns {Hex} The ABI-encoded payload with the updated `limit`.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return prepareERC20PeggedIncentivePayload({
+      asset: this.payload?.asset ?? zeroAddress,
+      peg: this.payload?.peg ?? zeroAddress,
+      reward: this.payload?.reward ?? 0n,
+      limit: netAmount,
+      manager: this.payload?.manager ?? zeroAddress,
+    });
+  }
 
   /**
    * Decodes claim data for the ERC20PeggedIncentive, returning the claim amount.

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -487,9 +487,9 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    * @param {bigint} netAmount - The additional limit to add to this incentive.
    * @returns {Hex} The ABI-encoded payload with the updated `limit`.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return prepareERC20PeggedIncentivePayload({
-      asset: this.payload?.asset ?? zeroAddress,
+      asset: (await this.asset()) ?? zeroAddress,
       peg: this.payload?.peg ?? zeroAddress,
       reward: this.payload?.reward ?? 0n,
       limit: netAmount,

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -622,9 +622,9 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
    * @param {bigint} netAmount - The additional limit to add to this incentive.
    * @returns {Hex} The ABI-encoded payload with the updated `limit`.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return prepareERC20PeggedVariableCriteriaIncentivePayload({
-      asset: this.payload?.asset ?? zeroAddress,
+      asset: (await this.asset()) ?? zeroAddress,
       peg: this.payload?.peg ?? zeroAddress,
       reward: this.payload?.reward ?? 0n,
       limit: netAmount,

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -614,6 +614,32 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the ERC20PeggedIncentive contract by incrementing
+   * the existing `limit` field by `netAmount`. The entire payload is then re-encoded
+   * via `prepareERC20PeggedIncentivePayload(...)`.
+   *
+   * @public
+   * @param {bigint} netAmount - The additional limit to add to this incentive.
+   * @returns {Hex} The ABI-encoded payload with the updated `limit`.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return prepareERC20PeggedVariableCriteriaIncentivePayload({
+      asset: this.payload?.asset ?? zeroAddress,
+      peg: this.payload?.peg ?? zeroAddress,
+      reward: this.payload?.reward ?? 0n,
+      limit: netAmount,
+      maxReward: this.payload?.maxReward ?? 0n,
+      manager: this.payload?.manager ?? zeroAddress,
+      criteria: this.payload?.criteria ?? {
+        criteriaType: 0,
+        signature: zeroAddress,
+        fieldIndex: 0,
+        targetContract: zeroAddress,
+      },
+    });
+  }
+
+  /**
    * @inheritdoc
    *
    * @public

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -404,12 +404,12 @@ export class ERC20VariableIncentive<
    * @param {bigint} netAmount - The additional limit to add to this incentive.
    * @returns {Hex} The ABI-encoded payload with the updated `limit`.
    */
-  public getTopupPayload(netAmount: bigint): Hex {
+  public async getTopupPayload(netAmount: bigint): Promise<Hex> {
     return prepareERC20VariableIncentivePayload({
-      asset: zeroAddress,
-      reward: 0n,
+      asset: (await this.asset()) as Address,
+      reward: netAmount,
       manager: zeroAddress,
-      limit: netAmount,
+      limit: 1n,
     });
   }
 

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -22,6 +22,7 @@ import {
   type Hex,
   decodeAbiParameters,
   encodeAbiParameters,
+  zeroAddress,
 } from 'viem';
 import { ERC20VariableIncentive as ERC20VariableIncentiveBases } from '../../dist/deployments.json';
 import type {
@@ -393,6 +394,23 @@ export class ERC20VariableIncentive<
       this.limit(params),
     ]);
     return limit - totalClaimed;
+  }
+  /**
+   * Generates a top-up payload for the ERC20PeggedIncentive contract by incrementing
+   * the existing `limit` field by `netAmount`. The entire payload is then re-encoded
+   * via `prepareERC20PeggedIncentivePayload(...)`.
+   *
+   * @public
+   * @param {bigint} netAmount - The additional limit to add to this incentive.
+   * @returns {Hex} The ABI-encoded payload with the updated `limit`.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return prepareERC20VariableIncentivePayload({
+      asset: zeroAddress,
+      reward: 0n,
+      manager: zeroAddress,
+      limit: netAmount,
+    });
   }
 
   /**

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -349,6 +349,28 @@ export class PointsIncentive extends DeployableTarget<
   }
 
   /**
+   * Generates a top-up payload for the PointsIncentive contract.
+   *
+   * @public
+   * @param {bigint} netAmount The net reward amount to be added to the incentive.
+   * @returns {Hex} The ABI-encoded top-up payload.
+   */
+  public getTopupPayload(netAmount: bigint): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'address', name: 'venue' },
+        { type: 'bytes4', name: 'selector' },
+        { type: 'uint256', name: 'amount' },
+      ],
+      [
+        this.payload?.venue ?? zeroHash,
+        this.payload?.selector ?? zeroHash,
+        netAmount,
+      ],
+    );
+  }
+
+  /**
    * Builds the claim data for the PointsIncentive.
    *
    * @public


### PR DESCRIPTION

### Description
Ended up adding helpers to every incentive to compose the correct payload for the topup so we can just call into that with the topup amount. I'm still torn, I think using a `Transfer` struct over an `InitPayload` struct might be better since we wouldn't need to call into the incentive as heavily. It also may make sense to add some additional tests with the other incentives. I'm not sure if we still want to add a helper to the budgets as well - I'm leaning towards yes - but that still needs to be added if so.
