### PR TITLE
[ADHOC] Allow overwrite of addresses in BoostCore

### DIFF
--- a/.changeset/late-boxes-sell.md
+++ b/.changeset/late-boxes-sell.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+allow overwrite of addresses in BoostCore SDK

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -211,9 +211,15 @@ export interface BoostCoreDeployedOptions extends DeployableOptions {
   /**
    * The address of a deployed, custom Boost Core contract.
    *
-   * @type {?Address}
+   * @type {Address}
    */
-  address?: Address;
+  address: Address;
+  /**
+   * The mapping of chain ID to address of deployed custom Boost Core contracts.
+   *
+   * @type {?Record<number, Address>}
+   */
+  addresses?: Record<number, Address>;
 }
 
 /**
@@ -325,7 +331,7 @@ export class BoostCore extends Deployable<
    * @readonly
    * @type {Record<string, Address>}
    */
-  static readonly addresses: Record<number, Address> = BOOST_CORE_ADDRESSES;
+  static addresses: Record<number, Address> = BOOST_CORE_ADDRESSES;
 
   /**
    * A getter that will return Boost core's static addresses by numerical chain ID
@@ -350,6 +356,9 @@ export class BoostCore extends Deployable<
   constructor({ config, account, ...options }: BoostCoreConfig) {
     if (isBoostCoreDeployed(options) && options.address) {
       super({ account, config }, options.address);
+      if (options.addresses) {
+        this.updateAddresses(options.addresses);
+      }
     } else if (isBoostCoreDeployable(options)) {
       super({ account, config }, [
         options.registryAddress,
@@ -496,6 +505,16 @@ export class BoostCore extends Deployable<
       chainId,
       args: [prepareBoostPayload(onChainPayload)],
     });
+  }
+
+  /**
+   * Updates the addresses for specific chain IDs. This is used when using a custom deployed instance
+   *
+   * @static
+   * @param {Record<number, Address>} newAddresses - New addresses to add/update
+   */
+  private updateAddresses(addresses: Record<number, Address>) {
+    BoostCore.addresses = addresses;
   }
 
   // This function mutates payload, which isn't awesome but it's fine


### PR DESCRIPTION
### Description
Despite passing in an address to the BoostCore, it is strictly tied to the current deployed addresses.

This change allows using the BoostCore instance to previous deployments of BoostCore