### PR TITLE
[ADHOC] test(sdk): ERC20PeggedVariableCriteriaIncentive core and topup testing

### DIFF
--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -32,6 +32,7 @@ import {
   parseEther,
   parseEventLogs,
   zeroAddress,
+  zeroHash,
 } from 'viem';
 import { ERC20PeggedVariableCriteriaIncentive as ERC20PeggedVariableCriteriaIncentiveBases } from '../../dist/deployments.json';
 import { SignatureType } from '../Actions/EventAction';
@@ -632,7 +633,7 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
       manager: this.payload?.manager ?? zeroAddress,
       criteria: this.payload?.criteria ?? {
         criteriaType: 0,
-        signature: zeroAddress,
+        signature: zeroHash,
         fieldIndex: 0,
         targetContract: zeroAddress,
       },

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -17,6 +17,7 @@ import {
   type ContractEventName,
   type Hex,
   encodeAbiParameters,
+  zeroAddress,
   zeroHash,
 } from 'viem';
 import { PointsIncentive as PointsIncentiveBases } from '../../dist/deployments.json';
@@ -363,8 +364,8 @@ export class PointsIncentive extends DeployableTarget<
         { type: 'uint256', name: 'amount' },
       ],
       [
-        this.payload?.venue ?? zeroHash,
-        this.payload?.selector ?? zeroHash,
+        this.payload?.venue ?? zeroAddress,
+        this.payload?.selector ?? '0x00000000',
         netAmount,
       ],
     );


### PR DESCRIPTION
### Description
Adds testing for `ERC20PeggedVariableCriteriaIncentive` in the boost core tests to ensure full compatability. Also adds tests for topup functionality with that specific configuration into the boost core tests and fixes the encoding issue that was found during integration. I also looked over the other functions that prepare the topup payloads to check for payload size conflicts and fixed a similar issue in the point incentive even though we're not using it right now.
