### PR TITLE
[ADHOC] feat(sdk): boost core defaults to LimitedSignerValidator

### DIFF
--- a/.changeset/chilled-walls-explode.md
+++ b/.changeset/chilled-walls-explode.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+Changes default behavior in boost creation to use a LimitedSignerValidator

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -1282,9 +1282,8 @@ describe("ERC20PeggedVariableCriteriaIncentive Top-Ups", () => {
 
 describe("ERC20PeggedVariableCriteriaIncentive with LimitedSignerValidator", () => {
   test("enforces validator claim limit", async () => {
-    // biome-ignore lint/style/noNonNullAssertion: we know this is defined
-    const referrer = accounts.at(1)!.account!;
-    const signer = accounts.at(0)!;
+    const referrer = accounts[1].account!;
+    const signer = accounts[0];
     const { core } = fixtures;
     const { budget, erc20 } = budgets;
 
@@ -1358,6 +1357,6 @@ describe("ERC20PeggedVariableCriteriaIncentive with LimitedSignerValidator", () 
     // Second claim should fail due to validator limit (specific error code)
     await expect(
       core.claimIncentive(boost.id, 0n, referrer, secondClaimPayload)
-    ).rejects.toThrow("0x059b7045");
+    ).rejects.toThrow("0x059b7045"); // BoostError.MaximumClaimed
   });
 });

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -527,13 +527,14 @@ export class BoostCore extends Deployable<
           Object.keys(this.addresses).map(Number),
         );
       const testnet = chain.testnet || chain.id === 31337;
-      payload.validator = this.SignerValidator({
+      payload.validator = this.LimitedSignerValidator({
         signers: [
           (testnet
             ? BoostValidatorEOA.TESTNET
             : BoostValidatorEOA.MAINNET) as unknown as Address,
         ],
         validatorCaller: coreAddress,
+        maxClaimCount: 1,
       });
     }
 

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -527,12 +527,20 @@ export class BoostCore extends Deployable<
           Object.keys(this.addresses).map(Number),
         );
       const testnet = chain.testnet || chain.id === 31337;
+      const signers = [
+        (testnet
+          ? BoostValidatorEOA.TESTNET
+          : BoostValidatorEOA.MAINNET) as unknown as Address,
+      ];
+
+      // This seemed like the best approach - I didn't want to use the testnet PK even in local testing
+      // May be another approach but this works for now and is pretty well isolated
+      if (chain.id === 31337) {
+        signers.push('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+      }
+
       payload.validator = this.LimitedSignerValidator({
-        signers: [
-          (testnet
-            ? BoostValidatorEOA.TESTNET
-            : BoostValidatorEOA.MAINNET) as unknown as Address,
-        ],
+        signers,
         validatorCaller: coreAddress,
         maxClaimCount: 1,
       });


### PR DESCRIPTION
### Description
Tweaks the default behavior of `BoostCore` in order to use a `LimitedSignerValidator` with a max claim count of 1 in cases where no validator is supplied (should be the majority of boost creations). Also adds code so that the default HH account 0 is added as a signer validator if the chain is a local test chain and adds tests to the boost core test suite to ensure this max claim count is enforced. There may be a better approach to adding the signer to the default `LimitedSignerValidator` but this avoid the need to pipe around even the testnet PK. That pattern is for sure the most questionable part of this PR though so probably deserves the most attention.
