### PR TITLE
[ADHOC] Decode Claim Data Update

### DIFF
--- a/.changeset/clean-parents-laugh.md
+++ b/.changeset/clean-parents-laugh.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+ERC20VariableIncentive and ERC20VaribleCritieriaIncentive decodeClaimData functions return Promise<bigint>

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -503,7 +503,7 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    *
    * @public
    * @param {Hex} claimData
-   * @returns {BigInt} Returns the reward amount from a claim data payload
+   * @returns {Promise<bigint>} Returns the reward amount from a claim data payload
    */
   public decodeClaimData(claimData: Hex) {
     const boostClaimData = decodeAbiParameters(
@@ -523,7 +523,7 @@ export class ERC20PeggedIncentive extends DeployableTarget<
       [{ type: 'uint256' }],
       boostClaimData[0].incentiveData,
     )[0];
-    return signedAmount;
+    return Promise.resolve(signedAmount);
   }
 }
 

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -503,7 +503,7 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    *
    * @public
    * @param {Hex} claimData
-   * @returns {Promise<bigint>} Returns the reward amount from a claim data payload
+   * @returns {bigint} Returns the reward amount from a claim data payload
    */
   public decodeClaimData(claimData: Hex) {
     const boostClaimData = decodeAbiParameters(
@@ -523,7 +523,7 @@ export class ERC20PeggedIncentive extends DeployableTarget<
       [{ type: 'uint256' }],
       boostClaimData[0].incentiveData,
     )[0];
-    return Promise.resolve(signedAmount);
+    return signedAmount;
   }
 }
 

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -696,7 +696,7 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
    *
    * @public
    * @param {Hex} claimData
-   * @returns {BigInt} Returns the reward amount from a claim data payload
+   * @returns {Promise<bigint>} Returns the reward amount from a claim data payload
    */
   public async decodeClaimData(claimData: Hex) {
     const boostClaimData = decodeAbiParameters(

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
@@ -114,7 +114,8 @@ export interface GetIncentiveScalarParams {
  */
 export class ERC20VariableCriteriaIncentive extends ERC20VariableIncentive<
   ERC20VariableCriteriaIncentivePayload,
-  typeof erc20VariableCriteriaIncentiveAbi
+  typeof erc20VariableCriteriaIncentiveAbi,
+  Promise<bigint>
 > {
   //@ts-expect-error instantiated correctly
   public override readonly abi = erc20VariableCriteriaIncentiveAbi;

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.test.ts
@@ -201,8 +201,8 @@ describe("ERC20VariableIncentive", () => {
       boostId: boost.id,
     });
 
-    const { incentiveData } = decodeClaimData(claimDataPayload)
-    expect(erc20VariableIncentive.decodeClaimData(incentiveData)).toBe(parseEther("1"))
+    const { incentiveData } = await decodeClaimData(claimDataPayload)
+    expect(await erc20VariableIncentive.decodeClaimData(incentiveData)).toBe(parseEther("1"))
   });
 
   test("can properly encode a uint256", () => {

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.test.ts
@@ -201,8 +201,8 @@ describe("ERC20VariableIncentive", () => {
       boostId: boost.id,
     });
 
-    const { incentiveData } = await decodeClaimData(claimDataPayload)
-    expect(await erc20VariableIncentive.decodeClaimData(incentiveData)).toBe(parseEther("1"))
+    const { incentiveData } = decodeClaimData(claimDataPayload)
+    expect(erc20VariableIncentive.decodeClaimData(incentiveData)).toBe(parseEther("1"))
   });
 
   test("can properly encode a uint256", () => {

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -101,6 +101,7 @@ export type ERC20VariableIncentiveLog<
 export class ERC20VariableIncentive<
   Payload = ERC20VariableIncentivePayload | undefined,
   ABI extends Abi = typeof erc20VariableIncentiveAbi,
+  DecodedClaimPayload = bigint,
 > extends DeployableTarget<Payload, ABI> {
   //@ts-expect-error it is instantiated correctly
   public override readonly abi = erc20VariableIncentiveAbi;
@@ -434,12 +435,11 @@ export class ERC20VariableIncentive<
    *
    * @public
    * @param {Hex} claimData
-   * @returns {Promise<bigint>} Returns the reward amount from a claim data payload
+   * @returns {bigint} Returns the reward amount from a claim data payload
    */
-  public decodeClaimData(data: Hex) {
-    return Promise.resolve(
-      BigInt(decodeAbiParameters([{ type: 'uint256' }], data)[0]),
-    );
+  public decodeClaimData(data: Hex): DecodedClaimPayload {
+    //@ts-expect-error making this generic to prevent major version
+    return BigInt(decodeAbiParameters([{ type: 'uint256' }], data)[0]);
   }
 
   /**

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -434,10 +434,12 @@ export class ERC20VariableIncentive<
    *
    * @public
    * @param {Hex} claimData
-   * @returns {BigInt} Returns the reward amount from a claim data payload
+   * @returns {Promise<bigint>} Returns the reward amount from a claim data payload
    */
   public decodeClaimData(data: Hex) {
-    return BigInt(decodeAbiParameters([{ type: 'uint256' }], data)[0]);
+    return Promise.resolve(
+      BigInt(decodeAbiParameters([{ type: 'uint256' }], data)[0]),
+    );
   }
 
   /**


### PR DESCRIPTION
### Description
- Updates the return type of `decodeClaimData` on `ERC20VariableIncentive` to return `Promise<bigint>` instead of `bigint`
- Adds `decodeClaimData` override for `ERC20VariableCriteriaIncentive`