### PR TITLE
[BOOST-5352] add valueType to incentiveCriteria Struct

### DIFF
--- a/.changeset/green-clouds-fly.md
+++ b/.changeset/green-clouds-fly.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+add valueType to variable incentive criteria

--- a/.changeset/green-clouds-fly.md
+++ b/.changeset/green-clouds-fly.md
@@ -1,6 +1,7 @@
 ---
 "@boostxyz/evm": minor
 "@boostxyz/sdk": minor
+"@boostxyz/cli": minor
 ---
 
 add valueType to variable incentive criteria

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -31,6 +31,7 @@ import {
   type SimpleAllowListPayload,
   type SimpleDenyListPayload,
   StrategyType,
+  ValueType,
   allowListFromAddress,
 } from '@boostxyz/sdk';
 import { MockERC20 } from '@boostxyz/test/MockERC20';
@@ -449,6 +450,7 @@ export const IncentiveCriteriaSchema = z.object({
   signature: zAbiItemSchema,
   fieldIndex: z.number().nonnegative(),
   targetContract: AddressSchema,
+  valueType: z.nativeEnum(ValueType),
 });
 
 export const ERC20VariableCriteriaIncentiveSchema = z.object({

--- a/packages/evm/contracts/incentives/AERC20PeggedVariableCriteriaIncentive.sol
+++ b/packages/evm/contracts/incentives/AERC20PeggedVariableCriteriaIncentive.sol
@@ -15,6 +15,11 @@ enum SignatureType {
     EVENT
 }
 
+enum ValueType {
+    RAW,
+    WAD
+}
+
 /// @title AERC20PeggedIncentive
 /// @notice An ERC20 incentive with pegged variable rewards
 abstract contract AERC20PeggedVariableCriteriaIncentive is AERC20PeggedIncentive {
@@ -25,6 +30,7 @@ abstract contract AERC20PeggedVariableCriteriaIncentive is AERC20PeggedIncentive
         bytes32 signature;
         uint8 fieldIndex;
         address targetContract;
+        ValueType valueType;
     }
 
     IncentiveCriteria public incentiveCriteria;

--- a/packages/evm/contracts/incentives/AERC20VariableCriteriaIncentive.sol
+++ b/packages/evm/contracts/incentives/AERC20VariableCriteriaIncentive.sol
@@ -13,6 +13,11 @@ enum SignatureType {
     EVENT
 }
 
+enum ValueType {
+    RAW,
+    WAD
+}
+
 /// @title Abstract ERC20 Incentive with Variable Criteria-Based Rewards
 /// @notice Defines the structure for ERC20VariableIncentive with incentive variability criteria, without implementations
 abstract contract AERC20VariableCriteriaIncentive is ERC20VariableIncentive {
@@ -25,6 +30,7 @@ abstract contract AERC20VariableCriteriaIncentive is ERC20VariableIncentive {
         bytes32 signature;
         uint8 fieldIndex;
         address targetContract;
+        ValueType valueType;
     }
 
     IncentiveCriteria public incentiveCriteria;

--- a/packages/evm/test/incentives/ERC20PeggedVariableCriteriaIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20PeggedVariableCriteriaIncentive.t.sol
@@ -12,7 +12,8 @@ import {ERC20PeggedVariableCriteriaIncentive} from "contracts/incentives/ERC20Pe
 import {AERC20PeggedIncentive} from "contracts/incentives/AERC20PeggedIncentive.sol";
 import {
     AERC20PeggedVariableCriteriaIncentive,
-    SignatureType
+    SignatureType,
+    ValueType
 } from "contracts/incentives/AERC20PeggedVariableCriteriaIncentive.sol";
 
 import {ABudget} from "contracts/budgets/ABudget.sol";
@@ -176,7 +177,8 @@ contract ERC20PeggedVariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         bytes memory preflightPayload = incentive.preflight(
             abi.encode(
@@ -329,7 +331,8 @@ contract ERC20PeggedVariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         return abi.encode(
             ERC20PeggedVariableCriteriaIncentive.InitPayload({

--- a/packages/evm/test/incentives/ERC20VariableCriteriaIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableCriteriaIncentive.t.sol
@@ -12,7 +12,7 @@ import {ERC20VariableCriteriaIncentive} from "contracts/incentives/ERC20Variable
 import {AERC20VariableCriteriaIncentive} from "contracts/incentives/AERC20VariableCriteriaIncentive.sol";
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {AIncentive, IBoostClaim} from "contracts/incentives/AIncentive.sol";
-import {SignatureType} from "contracts/incentives/AERC20VariableCriteriaIncentive.sol";
+import {SignatureType, ValueType} from "contracts/incentives/AERC20VariableCriteriaIncentive.sol";
 
 contract ERC20VariableCriteriaIncentiveTest is Test {
     using SafeTransferLib for address;
@@ -42,7 +42,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
 
         // Encode and initialize the contract
@@ -68,7 +69,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
 
         // Attempt to initialize with a limit greater than available funds => revert
@@ -92,7 +94,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
 
         // Initialize with limit = zero
@@ -121,7 +124,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         // Initialize the ERC20VariableIncentive with reward and maxReward constraints
         uint256 reward = 0; // set to zero to test maxReward cap
@@ -152,7 +156,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         // Initialize the ERC20VariableIncentive with reward and maxReward constraints
         uint256 reward = 0; // set to zero to test maxReward cap
@@ -189,7 +194,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         uint256 maxReward = 1.5 ether; // Set a max reward cap
 
@@ -219,7 +225,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.EVENT,
             signature: keccak256("Transfer(address,address,uint256)"),
             fieldIndex: 2,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         uint256 maxReward = 1.5 ether; // Set a max reward cap
 
@@ -245,7 +252,8 @@ contract ERC20VariableCriteriaIncentiveTest is Test {
             criteriaType: SignatureType.FUNC,
             signature: keccak256("transfer(address,uint256)"),
             fieldIndex: 1,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            valueType: ValueType.WAD
         });
         _initialize(address(mockAsset), 2 ether, 10, 0, criteria);
 

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -147,7 +147,7 @@ export enum SignatureType {
 }
 
 /**
- * The type of value used for the reward calculation (RAW or WAD).
+ * The type of value used for the scalar value (RAW or WAD).
  *
  * @export
  * @enum {number}

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -147,6 +147,17 @@ export enum SignatureType {
 }
 
 /**
+ * The type of value used for the reward calculation (RAW or WAD).
+ *
+ * @export
+ * @enum {number}
+ */
+export enum ValueType {
+  RAW = 0,
+  WAD = 1,
+}
+
+/**
  *  The payload describing how claimants are identified
  *
  * @export

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -20,7 +20,8 @@ import { bytes4 } from "./utils";
 import { BoostValidatorEOA } from './Validators/Validator';
 import { AssetType } from "./transfers";
 import { waitForTransactionReceipt } from "@wagmi/core";
-import { SignatureType } from "./Actions/EventAction";
+import { SignatureType, ValueType } from "./Actions/EventAction";
+import { MockERC721 } from "@boostxyz/test/MockERC721";
 
 let fixtures: Fixtures, budgets: BudgetFixtures;
 
@@ -975,6 +976,7 @@ describe("BoostCore", () => {
         signature: pad(bytes4("transferFrom(address,address,uint256)")),
         fieldIndex: 2,
         targetContract: erc721.assertValidAddress(),
+        valueType: ValueType.WAD,
       },
     });
 
@@ -1021,6 +1023,7 @@ describe("BoostCore", () => {
     expect(criteria.targetContract.toLowerCase()).toBe(
       erc721.address?.toLowerCase(),
     );
+    expect(criteria.valueType).toBe(ValueType.WAD);
   });
 });
 
@@ -1149,7 +1152,7 @@ describe("Top-Up Incentives", () => {
 describe("ERC20PeggedVariableCriteriaIncentive Top-Ups", () => {
   let incentive: ReturnType<typeof fixtures.core.ERC20PeggedVariableCriteriaIncentive>;
   let boostId: bigint;
-  let erc721: ReturnType<typeof fundErc721>;
+  let erc721: MockERC721;
 
   beforeAll(async () => {
     const { core } = fixtures;
@@ -1170,6 +1173,7 @@ describe("ERC20PeggedVariableCriteriaIncentive Top-Ups", () => {
         signature: pad(bytes4("transferFrom(address,address,uint256)")),
         fieldIndex: 2,
         targetContract: erc721.assertValidAddress(),
+        valueType: ValueType.WAD,
       },
     });
 
@@ -1300,6 +1304,7 @@ describe("ERC20PeggedVariableCriteriaIncentive with LimitedSignerValidator", () 
         signature: pad(bytes4("transferFrom(address,address,uint256)")),
         fieldIndex: 2,
         targetContract: erc721.assertValidAddress(),
+        valueType: ValueType.WAD,
       },
     });
     await erc20.mint(defaultOptions.account.address, parseEther("110"));

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.test.ts
@@ -23,7 +23,7 @@ import {
   zeroHash,
 } from "viem";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
-import { SignatureType } from "../Actions/EventAction";
+import { SignatureType, ValueType } from "../Actions/EventAction";
 import type { Boost } from "../Boost";
 import {
   type ERC20PeggedVariableCriteriaIncentive,
@@ -49,6 +49,7 @@ export function basicErc721TransferScalarCriteria(
     signature: funcSelectors["transferFrom(address,address,uint256)"] as Hex, // Function selector for mint
     fieldIndex: 2, // Field where the scalar value resides
     targetContract: erc721.assertValidAddress(),
+    valueType: ValueType.WAD,
   };
 }
 
@@ -68,6 +69,7 @@ export function basicErc721MintScalarCriteria(
     ] as Hex, // Function selector for mint
     fieldIndex: 2, // Field where the scalar value resides
     targetContract: erc721.assertValidAddress(),
+    valueType: ValueType.WAD,
   };
 }
 
@@ -239,6 +241,7 @@ describe("ERC20PeggedVariableCriteriaIncentive", () => {
         signature: zeroHash,
         fieldIndex: 255,
         targetContract: zeroAddress,
+        valueType: ValueType.WAD,
       });
 
       boost = await freshBoost(fixtures, {
@@ -254,6 +257,7 @@ describe("ERC20PeggedVariableCriteriaIncentive", () => {
       expect(deployedCriteria.signature).toBe(zeroHash);
       expect(deployedCriteria.fieldIndex).toBe(255);
       expect(deployedCriteria.targetContract).toBe(zeroAddress);
+      expect(deployedCriteria.valueType).toBe(ValueType.WAD);
     });
 
     test("should throw NoMatchingLogsError for event criteria with no matching logs", async () => {

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -636,6 +636,7 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
         signature: zeroHash,
         fieldIndex: 0,
         targetContract: zeroAddress,
+        valueType: 0,
       },
     });
   }
@@ -825,6 +826,7 @@ export function prepareERC20PeggedVariableCriteriaIncentivePayload({
               { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'fieldIndex' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint8', name: 'valueType' },
             ],
           },
         ],
@@ -843,6 +845,7 @@ export function prepareERC20PeggedVariableCriteriaIncentivePayload({
           signature: criteria.signature,
           fieldIndex: criteria.fieldIndex,
           targetContract: criteria.targetContract,
+          valueType: criteria.valueType,
         },
       },
     ],

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.test.ts
@@ -23,7 +23,7 @@ import {
   zeroHash,
 } from "viem";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
-import { SignatureType } from "../Actions/EventAction";
+import { SignatureType, ValueType } from "../Actions/EventAction";
 import type { Boost } from "../Boost";
 import {
   type ERC20VariableCriteriaIncentive,
@@ -47,6 +47,7 @@ export function basicErc721TransferScalarCriteria(
     signature: funcSelectors["transferFrom(address,address,uint256)"] as Hex, // Function selector for mint
     fieldIndex: 2, // Field where the scalar value resides
     targetContract: erc721.assertValidAddress(),
+    valueType: ValueType.WAD,
   };
 }
 
@@ -66,6 +67,7 @@ export function basicErc721MintScalarCriteria(
     ] as Hex, // Function selector for mint
     fieldIndex: 2, // Field where the scalar value resides
     targetContract: erc721.assertValidAddress(),
+    valueType: ValueType.WAD,
   };
 }
 
@@ -126,6 +128,7 @@ describe("ERC20VariableCriteriaIncentive", () => {
         signature: expect.any(String),
         fieldIndex: expect.any(Number),
         targetContract: expect.any(String),
+        valueType: expect.any(Number),
       });
     });
   });
@@ -194,6 +197,7 @@ describe("ERC20VariableCriteriaIncentive", () => {
         signature: zeroHash,
         fieldIndex: 255,
         targetContract: zeroAddress,
+        valueType: ValueType.WAD,
       });
 
       boost = await freshBoost(fixtures, {
@@ -209,6 +213,7 @@ describe("ERC20VariableCriteriaIncentive", () => {
       expect(deployedCriteria.signature).toBe(zeroHash);
       expect(deployedCriteria.fieldIndex).toBe(255);
       expect(deployedCriteria.targetContract).toBe(zeroAddress);
+      expect(deployedCriteria.valueType).toBe(ValueType.WAD);
     });
 
     test("should throw NoMatchingLogsError for event criteria with no matching logs", async () => {

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
@@ -95,7 +95,7 @@ export interface IncentiveCriteria {
    */
   targetContract: Address;
   /**
-   * The type of value used for the reward calculation (RAW or WAD).
+   * The type of value used for the scalar value (RAW or WAD).
    * - RAW: Raw integer value (e.g., NFT quantity)
    * - WAD: Value with 18 decimals (e.g., token amount)
    *

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
@@ -19,7 +19,7 @@ import {
   zeroHash,
 } from 'viem';
 import { ERC20VariableCriteriaIncentive as ERC20VariableCriteriaIncentiveBases } from '../../dist/deployments.json';
-import { SignatureType } from '../Actions/EventAction';
+import { SignatureType, ValueType } from '../Actions/EventAction';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -94,6 +94,14 @@ export interface IncentiveCriteria {
    * @type {Address}
    */
   targetContract: Address;
+  /**
+   * The type of value used for the reward calculation (RAW or WAD).
+   * - RAW: Raw integer value (e.g., NFT quantity)
+   * - WAD: Value with 18 decimals (e.g., token amount)
+   *
+   * @type {ValueType}
+   */
+  valueType: ValueType;
 }
 
 export interface ReadIncentiveCriteriaParams extends ReadParams {}
@@ -374,6 +382,7 @@ export function gasRebateIncentiveCriteria(): IncentiveCriteria {
     signature: zeroHash,
     fieldIndex: CheatCodes.GAS_REBATE_INCENTIVE,
     targetContract: zeroAddress,
+    valueType: ValueType.WAD,
   };
 }
 
@@ -413,6 +422,7 @@ export function prepareERC20VariableCriteriaIncentivePayload({
               { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'fieldIndex' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint8', name: 'valueType' },
             ],
           },
         ],
@@ -429,6 +439,7 @@ export function prepareERC20VariableCriteriaIncentivePayload({
           signature: criteria.signature,
           fieldIndex: criteria.fieldIndex,
           targetContract: criteria.targetContract,
+          valueType: criteria.valueType,
         },
       },
     ],


### PR DESCRIPTION
### Description
Adds a `valueType` param to the incentiveCriteria for variable incentive types. This is necessary as we treat these values differently when calculating the reward values. 
