### PR TITLE
[BOOST-5496] incentive criteria tuple support

### DIFF
--- a/.changeset/red-beds-repair.md
+++ b/.changeset/red-beds-repair.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+add tuple support for incentive criteria

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1525,16 +1525,16 @@ describe("criteria field index tuple support", () => {
     });
 
     test("throws error if any index exceeds the allowed range (0-12)", () => {
-      expect(() => packCriteriaFieldIndexes([13, 5])).toThrowError(
-        "Tuple indices must be between 0-12"
+      expect(() => packCriteriaFieldIndexes([14, 5])).toThrowError(
+        "Tuple indices must be between 0-13"
       );
 
-      expect(() => packCriteriaFieldIndexes([5, 13])).toThrowError(
-        "Tuple indices must be between 0-12"
+      expect(() => packCriteriaFieldIndexes([5, 14])).toThrowError(
+        "Tuple indices must be between 0-13"
       );
 
       expect(() => packCriteriaFieldIndexes([-1, 5])).toThrowError(
-        "Tuple indices must be between 0-12"
+        "Tuple indices must be between 0-13"
       );
     });
 
@@ -1560,15 +1560,15 @@ describe("criteria field index tuple support", () => {
 
     test("throws error if packed value is out of valid range", () => {
       expect(() => unpackCriteriaFieldIndexes(15)).toThrowError(
-        "Field index must be between 32-236"
+        "Field index must be between 32-253"
       );
       
-      expect(() => unpackCriteriaFieldIndexes(237)).toThrowError(
-        "Field index must be between 32-236"
+      expect(() => unpackCriteriaFieldIndexes(254)).toThrowError(
+        "Field index must be between 32-253"
       );
 
       expect(() => unpackCriteriaFieldIndexes(-1)).toThrowError(
-        "Field index must be between 32-236"
+        "Field index must be between 32-253"
       );
     });
   });
@@ -1591,8 +1591,8 @@ describe("criteria field index tuple support", () => {
 
   describe("criteria field index functions in practice", () => {
     test("round-trip packing and unpacking preserves the original values", () => {
-      for (let i = 0; i <= 12; i++) {
-        for (let j = 0; j <= 12; j++) {
+      for (let i = 0; i <= 13; i++) {
+        for (let j = 0; j <= 13; j++) {
           const original: [number, number] = [i, j];
           const packed = packCriteriaFieldIndexes(original);
           const unpacked = unpackCriteriaFieldIndexes(packed);

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1524,7 +1524,7 @@ describe("criteria field index tuple support", () => {
       expect(packed).toBeLessThanOrEqual(236);
     });
 
-    test("throws error if any index exceeds the allowed range (0-12)", () => {
+    test("throws error if any index exceeds the allowed range (0-13)", () => {
       expect(() => packCriteriaFieldIndexes([14, 5])).toThrowError(
         "Tuple indices must be between 0-13"
       );

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1557,22 +1557,17 @@ describe("criteria field index tuple support", () => {
       expect(result).toEqual([4, 7]);
     });
 
-    test("correctly identifies simple index values (< 32)", () => {
-      // Simple index value (not a tuple)
-      const simpleIndex = 15;
-      const result = unpackCriteriaFieldIndexes(simpleIndex);
-
-      expect(result).toEqual([15]); // Should return as a single-element array
-      expect(result.length).toBe(1);
-    });
-
     test("throws error if packed value is out of valid range", () => {
+      expect(() => unpackCriteriaFieldIndexes(15)).toThrowError(
+        "Field index must be between 32-236"
+      );
+      
       expect(() => unpackCriteriaFieldIndexes(237)).toThrowError(
-        "Field index must be between 0-236"
+        "Field index must be between 32-236"
       );
 
       expect(() => unpackCriteriaFieldIndexes(-1)).toThrowError(
-        "Field index must be between 0-236"
+        "Field index must be between 32-236"
       );
     });
   });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1520,7 +1520,8 @@ describe("criteria field index tuple support", () => {
   describe("packCriteriaFieldIndexes", () => {
     test("packs two indices into a single value", () => {
       const packed = packCriteriaFieldIndexes([3, 5])
-      expect(packed).toBeGreaterThanOrEqual(32); // Should be offset by 32 to indicate tuple
+      expect(packed).toBeGreaterThanOrEqual(32);
+      expect(packed).toBeLessThanOrEqual(236);
     });
 
     test("throws error if any index exceeds the allowed range (0-12)", () => {

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1521,7 +1521,7 @@ describe("criteria field index tuple support", () => {
     test("packs two indices into a single value", () => {
       const packed = packCriteriaFieldIndexes([3, 5])
       expect(packed).toBeGreaterThanOrEqual(32);
-      expect(packed).toBeLessThanOrEqual(236);
+      expect(packed).toBeLessThanOrEqual(253);
     });
 
     test("throws error if any index exceeds the allowed range (0-13)", () => {

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1519,22 +1519,8 @@ describe('decodeAndReorderLogArgs', () => {
 describe("criteria field index tuple support", () => {
   describe("packCriteriaFieldIndexes", () => {
     test("packs two indices into a single value", () => {
-      const indexes = [3, 5]; // sample indices for tuple access
-      const packed = packCriteriaFieldIndexes(indexes);
-
+      const packed = packCriteriaFieldIndexes([3, 5])
       expect(packed).toBeGreaterThanOrEqual(32); // Should be offset by 32 to indicate tuple
-    });
-
-    test("throws error if more than 2 indices are provided", () => {
-      expect(() => packCriteriaFieldIndexes([1, 2, 3])).toThrowError(
-        "Expected 2 indices, got 3 indices"
-      );
-    });
-
-    test("throws error if fewer than 2 indices are provided", () => {
-      expect(() => packCriteriaFieldIndexes([1])).toThrowError(
-        "Expected 2 indices, got 1 indices"
-      );
     });
 
     test("throws error if any index exceeds the allowed range (0-12)", () => {
@@ -1564,12 +1550,11 @@ describe("criteria field index tuple support", () => {
 
   describe("unpackCriteriaFieldIndexes", () => {
     test("unpacks tuple index values (>= 32) correctly", () => {
-      const indexes = [4, 7];
-      const packed = packCriteriaFieldIndexes(indexes);
+      const packed = packCriteriaFieldIndexes([4, 7]);
 
       const result = unpackCriteriaFieldIndexes(packed);
       expect(result.length).toBe(2);
-      expect(result).toEqual(indexes);
+      expect(result).toEqual([4, 7]);
     });
 
     test("correctly identifies simple index values (< 32)", () => {
@@ -1612,7 +1597,7 @@ describe("criteria field index tuple support", () => {
     test("round-trip packing and unpacking preserves the original values", () => {
       for (let i = 0; i <= 12; i++) {
         for (let j = 0; j <= 12; j++) {
-          const original = [i, j];
+          const original: [number, number] = [i, j];
           const packed = packCriteriaFieldIndexes(original);
           const unpacked = unpackCriteriaFieldIndexes(packed);
           expect(unpacked).toEqual(original);

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1810,23 +1810,16 @@ export function packCriteriaFieldIndexes([firstIndex, secondIndex]: [
 
 /**
  * Unpacks a uint8 fieldIndex value into an array of indices.
- * If the value is < 32, it's treated as a simple field index.
- * Otherwise, it's always unpacked as exactly two tuple indices.
  *
  * @export
  * @param {number} fieldIndex - Field index value
- * @returns {number[]} - Either [singleIndex] or [firstIndex, secondIndex]
+ * @returns {[number, number]} - [firstIndex, secondIndex]
  */
-export function unpackCriteriaFieldIndexes(packed: number): number[] {
-  if (packed < 0 || packed > 236) {
+export function unpackCriteriaFieldIndexes(packed: number): [number, number] {
+  if (packed < 32 || packed > 236) {
     throw new InvalidTupleEncodingError(
-      `Field index must be between 0-236, got: ${packed}`,
+      `Field index must be between 32-236, got: ${packed}`,
     );
-  }
-
-  if (packed < 32) {
-    // not a tuple, return the single index
-    return [packed];
   }
 
   const tupleValue = packed - 32;

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1784,7 +1784,7 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
 
 /**
  * Packs two field indices into a single uint8 value for criteria tuple access.
- * Both indices must be between 0-12 to fit in the packed format.
+ * Both indices must be between 0-13 to fit in the packed format.
  *
  * @export
  * @param {[number, number]} param0 - A tuple of [firstIndex, secondIndex]

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1783,8 +1783,14 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
 }
 
 /**
+ * IMPORTANT: For variable incentive criteria use only.
+ * Do NOT use for action steps - use {@link packFieldIndexes} instead.
+ *
  * Packs two field indices into a single uint8 value for criteria tuple access.
  * Both indices must be between 0-13 to fit in the packed format.
+ *
+ * Uses an offset of 32 to avoid collision with normal field indices (which are 0-31),
+ * allowing the system to distinguish between direct field access and tuple access.
  *
  * @export
  * @param {[number, number]} param0 - A tuple of [firstIndex, secondIndex]

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1788,8 +1788,8 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
  * - Two indices are packed with a base offset of 32
  *
  * @export
- * @param {number[]} indexes - Array of indices (1 or 2 elements)
- * @returns {number} - Packed uint8 value between 0-236
+ * @param {number[]} indexes - Array of indices
+ * @returns {number} - Packed uint8 value
  * @throws {InvalidTupleEncodingError} - If indices are invalid
  */
 export function packCriteriaFieldIndexes(indexes: number[]): number {

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1783,36 +1783,29 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
 }
 
 /**
- * Packs field indices into a single uint8 value for criteria tuple access.
- * - Single index < 32 is returned directly
- * - Two indices are packed with a base offset of 32
+ * Packs two field indices into a single uint8 value for criteria tuple access.
+ * Both indices must be between 0-12 to fit in the packed format.
  *
  * @export
- * @param {number[]} indexes - Array of indices
- * @returns {number} - Packed uint8 value
- * @throws {InvalidTupleEncodingError} - If indices are invalid
+ * @param {[number, number]} param0 - A tuple of [firstIndex, secondIndex]
+ * @returns {number} - Packed uint8 value with base offset of 32
+ * @throws {InvalidTupleEncodingError} - If either index is outside the valid range (0-12)
  */
-export function packCriteriaFieldIndexes(indexes: number[]): number {
-  if (indexes.length !== 2) {
-    throw new InvalidTupleEncodingError(
-      `Expected 2 indices, got ${indexes.length} indices`,
-    );
-  }
-
-  const [first, second] = indexes;
+export function packCriteriaFieldIndexes([firstIndex, secondIndex]: [
+  number,
+  number,
+]): number {
   if (
-    first === undefined ||
-    second === undefined ||
-    first < 0 ||
-    first > 12 ||
-    second < 0 ||
-    second > 12
+    firstIndex < 0 ||
+    firstIndex > 12 ||
+    secondIndex < 0 ||
+    secondIndex > 12
   ) {
     throw new InvalidTupleEncodingError(
-      `Tuple indices must be between 0-12, got: [${first}, ${second}]`,
+      `Tuple indices must be between 0-12, got: [${firstIndex}, ${secondIndex}]`,
     );
   }
-  return 32 + (first << 4) + second;
+  return 32 + (firstIndex << 4) + secondIndex;
 }
 
 /**

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1789,7 +1789,7 @@ export function decodeAndReorderLogArgs(event: AbiEvent, log: Log) {
  * @export
  * @param {[number, number]} param0 - A tuple of [firstIndex, secondIndex]
  * @returns {number} - Packed uint8 value with base offset of 32
- * @throws {InvalidTupleEncodingError} - If either index is outside the valid range (0-12)
+ * @throws {InvalidTupleEncodingError} - If either index is outside the valid range (0-13)
  */
 export function packCriteriaFieldIndexes([firstIndex, secondIndex]: [
   number,
@@ -1797,12 +1797,12 @@ export function packCriteriaFieldIndexes([firstIndex, secondIndex]: [
 ]): number {
   if (
     firstIndex < 0 ||
-    firstIndex > 12 ||
+    firstIndex > 13 ||
     secondIndex < 0 ||
-    secondIndex > 12
+    secondIndex > 13
   ) {
     throw new InvalidTupleEncodingError(
-      `Tuple indices must be between 0-12, got: [${firstIndex}, ${secondIndex}]`,
+      `Tuple indices must be between 0-13, got: [${firstIndex}, ${secondIndex}]`,
     );
   }
   return 32 + (firstIndex << 4) + secondIndex;
@@ -1816,9 +1816,9 @@ export function packCriteriaFieldIndexes([firstIndex, secondIndex]: [
  * @returns {[number, number]} - [firstIndex, secondIndex]
  */
 export function unpackCriteriaFieldIndexes(packed: number): [number, number] {
-  if (packed < 32 || packed > 236) {
+  if (packed < 32 || packed > 253) {
     throw new InvalidTupleEncodingError(
-      `Field index must be between 32-236, got: ${packed}`,
+      `Field index must be between 32-253, got: ${packed}`,
     );
   }
 

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1809,10 +1809,10 @@ export function packCriteriaFieldIndexes([firstIndex, secondIndex]: [
 }
 
 /**
- * Unpacks a uint8 fieldIndex value into an array of indices.
+ * Unpacks a uint8 packed index value into an array of indices.
  *
  * @export
- * @param {number} fieldIndex - Field index value
+ * @param {number} packed - Packed index value
  * @returns {[number, number]} - [firstIndex, secondIndex]
  */
 export function unpackCriteriaFieldIndexes(packed: number): [number, number] {

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.ts
@@ -19,7 +19,12 @@ import {
   zeroHash,
 } from 'viem';
 import { ERC20VariableCriteriaIncentiveV2 as ERC20VariableCriteriaIncentiveV2Bases } from '../../dist/deployments.json';
-import { SignatureType, ValueType } from '../Actions/EventAction';
+import {
+  SignatureType,
+  ValueType,
+  getScalarValueFromTuple,
+  isCriteriaFieldIndexTuple,
+} from '../Actions/EventAction';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -268,7 +273,6 @@ export class ERC20VariableCriteriaIncentiveV2 extends ERC20VariableIncentive<
 
       // Decode the event log
       try {
-        // Decode function data
         const eventAbi = knownSignatures[criteria.signature] as AbiEvent;
         const decodedEvents = parseEventLogs({
           abi: [eventAbi],
@@ -279,10 +283,18 @@ export class ERC20VariableCriteriaIncentiveV2 extends ERC20VariableIncentive<
             `No logs found for event signature ${criteria.signature}`,
           );
         }
-        const scalarValue = (decodedEvents[0]?.args as string[])[
-          criteria.fieldIndex
-        ];
 
+        if (isCriteriaFieldIndexTuple(criteria.fieldIndex)) {
+          return getScalarValueFromTuple(
+            decodedEvents[0]?.args as unknown[],
+            criteria.fieldIndex,
+          );
+        }
+
+        const scalarValue =
+          decodedEvents[0] && decodedEvents[0].args
+            ? (decodedEvents[0].args as string[])[criteria.fieldIndex]
+            : undefined;
         if (scalarValue === undefined) {
           throw new DecodedArgsError(
             `Decoded argument at index ${criteria.fieldIndex} is undefined`,
@@ -307,6 +319,14 @@ export class ERC20VariableCriteriaIncentiveV2 extends ERC20VariableIncentive<
           abi: [func],
           data: transaction.input,
         });
+
+        if (isCriteriaFieldIndexTuple(criteria.fieldIndex)) {
+          return getScalarValueFromTuple(
+            decodedFunction.args as unknown[],
+            criteria.fieldIndex,
+          );
+        }
+
         const scalarValue = decodedFunction.args[criteria.fieldIndex] as string;
         if (scalarValue === undefined || scalarValue === null) {
           throw new DecodedArgsError(


### PR DESCRIPTION
### Description
- adds tuple support for incentive criteria in variable incentives

Unfortunately we only have 8-bits to work with on the criteria field index, so we treat the first 32 indexes as normal, and the rest (32-253) are available for packing the tuple parameters.

Due to this limitation, the tuple must be within the first 14 arg parameters, and the value we want to access must be an integer value within the first 14 parameters of the tuple.
