### PR TITLE
[BOOST-5513] use actionSteps logs to determine claimant

### DIFF
--- a/.changeset/little-goats-vanish.md
+++ b/.changeset/little-goats-vanish.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+derive claimant from actionStep logs

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1260,26 +1260,26 @@ export class EventAction extends DeployableTarget<
   }
 
   /**
-   * Validates action steps and returns both the result and the matching logs.
-   * Returns early with {valid: false, matchedLogs: []} if any step fails validation.
+   * Validates action steps and returns any matching logs.
    *
    * @public
    * @async
    * @param {ValidateActionStepParams} params
-   * @returns {Promise<{valid: boolean; matchedLogs: EventLog[]}>}
+   * @returns {Promise<{allStepsValid: boolean; matchedLogs: EventLog[]}>}
    */
   public async validateActionStepsWithLogs(
     params: ValidateActionStepParams,
   ): Promise<{
-    valid: boolean;
+    allStepsValid: boolean;
     matchedLogs: EventLog[];
   }> {
     const actionSteps = await this.getActionSteps();
     const matchedLogs: EventLog[] = [];
+    let allStepsValid = true;
 
     for (const actionStep of actionSteps) {
       if (!(await this.isActionStepValid(actionStep, params))) {
-        return { valid: false, matchedLogs: [] };
+        allStepsValid = false;
       }
 
       if (actionStep.signatureType === SignatureType.EVENT) {
@@ -1291,7 +1291,7 @@ export class EventAction extends DeployableTarget<
       }
     }
 
-    return { valid: true, matchedLogs };
+    return { allStepsValid, matchedLogs };
   }
 
   /**

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -1283,7 +1283,7 @@ export class EventAction extends DeployableTarget<
   }
 
   /**
-   * Finds logs that match a specific action step.
+   * Finds logs that match the criteria for a specific action step.
    *
    * @public
    * @async


### PR DESCRIPTION
### Description
- returns the logs used to validate the actionSteps so they can be used to determine the Claimant and RewardScalar
- `getLogsFromActionSteps` borrows a lot of the logic from `validateActionSteps` . The main difference is that it returns the logs used to validate the actionSteps instead of a boolean. This allows us to retain backwards compatibility by leaving the existing validateActionSteps methods untouched.
- if logs are passed into `deriveActionClaimantFromTransaction`, we use those logs first, these will be the logs that we used to validate the action steps. If a claimant is not found off these logs, we continue with the existing logic.
