### PR TITLE
Matthew/boost 5517 allow 4byte selectors in criteria

### DIFF
--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -29,6 +29,7 @@ import {
   decodeAbiParameters,
   decodeFunctionData,
   encodeAbiParameters,
+  pad,
   parseEther,
   parseEventLogs,
   zeroAddress,
@@ -842,7 +843,7 @@ export function prepareERC20PeggedVariableCriteriaIncentivePayload({
         maxReward,
         criteria: {
           criteriaType: criteria.criteriaType,
-          signature: criteria.signature,
+          signature: pad(criteria.signature),
           fieldIndex: criteria.fieldIndex,
           targetContract: criteria.targetContract,
         },

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentiveV2.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentiveV2.ts
@@ -29,6 +29,7 @@ import {
   decodeAbiParameters,
   decodeFunctionData,
   encodeAbiParameters,
+  pad,
   parseEther,
   parseEventLogs,
   zeroAddress,
@@ -880,7 +881,7 @@ export function prepareERC20PeggedVariableCriteriaIncentiveV2Payload({
         maxReward,
         criteria: {
           criteriaType: criteria.criteriaType,
-          signature: criteria.signature,
+          signature: pad(criteria.signature),
           fieldIndex: criteria.fieldIndex,
           targetContract: criteria.targetContract,
           valueType: criteria.valueType,

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
@@ -13,6 +13,7 @@ import {
   decodeAbiParameters,
   decodeFunctionData,
   encodeAbiParameters,
+  pad,
   parseEther,
   parseEventLogs,
   zeroAddress,
@@ -427,7 +428,7 @@ export function prepareERC20VariableCriteriaIncentivePayload({
         maxReward: maxReward,
         criteria: {
           criteriaType: criteria.criteriaType,
-          signature: criteria.signature,
+          signature: pad(criteria.signature),
           fieldIndex: criteria.fieldIndex,
           targetContract: criteria.targetContract,
         },

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.test.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.test.ts
@@ -272,4 +272,32 @@ describe("ERC20VariableCriteriaIncentiveV2", () => {
       true,
     );
   });
+
+  test("should deploy with a 4-byte function selector", async () => {
+    const fourByteSignature = "0xa9059cbb" as Hex; // transfer(address,uint256)
+
+    const incentiveWithFourByteSelector = fixtures.core.ERC20VariableCriteriaIncentiveV2({
+      asset: budgets.erc20.assertValidAddress(),
+      limit: 1000000n,
+      reward: 1000000n,
+      criteria: {
+        criteriaType: SignatureType.FUNC,
+        signature: fourByteSignature,
+        fieldIndex: 1,
+        targetContract: budgets.erc20.assertValidAddress(),
+        valueType: ValueType.WAD,
+      },
+    });
+
+    const newBoost = await freshBoost(fixtures, {
+      budget: budgets.budget,
+      incentives: [incentiveWithFourByteSelector],
+    });
+    const incentive = newBoost.incentives[0] as ERC20VariableCriteriaIncentiveV2;
+    const deployedCriteria = await incentive.getIncentiveCriteria();
+
+    expect(isAddress(newBoost.incentives[0]!.assertValidAddress())).toBe(true);
+    expect(deployedCriteria.signature.length).toBe(66);
+    expect(deployedCriteria.signature.endsWith(fourByteSignature.slice(2))).toBe(true);
+  });
 });

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.ts
@@ -13,6 +13,7 @@ import {
   decodeAbiParameters,
   decodeFunctionData,
   encodeAbiParameters,
+  pad,
   parseEther,
   parseEventLogs,
   zeroAddress,
@@ -456,7 +457,7 @@ export function prepareERC20VariableCriteriaIncentiveV2Payload({
         maxReward: maxReward,
         criteria: {
           criteriaType: criteria.criteriaType,
-          signature: criteria.signature,
+          signature: pad(criteria.signature),
           fieldIndex: criteria.fieldIndex,
           targetContract: criteria.targetContract,
           valueType: criteria.valueType,


### PR DESCRIPTION
### Description
Allows for 4-byte function signatures in incentive criteria. This is so it is consistent with the claimant and actionsteps signature which also allows 4-byte format. Anytime a 4-byte function signature is provided, we automatically pad it to the required 32-bytes.

**Related PR:**
Allow 4-byte signature in claimant and actionsteps: https://github.com/boostxyz/boost-protocol/pull/375
