### PR TITLE
[ADHOC] conditionally add hardhat chain to bases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ packages/evm/artifacts/
 !packages/evm/broadcast
 packages/evm/broadcast/*/31337/
 packages/evm/broadcast/**/dry-run/
+
+#cursor-rules
+.cursor/rules/*

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -380,7 +380,9 @@ export class EventAction extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_EVENT_ACTION_BASE,
+    ...(import.meta.env?.VITE_EVENT_ACTION_BASE
+      ? { 31337: import.meta.env.VITE_EVENT_ACTION_BASE }
+      : {}),
     ...(EventActionBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/AllowLists/SimpleAllowList.ts
+++ b/packages/sdk/src/AllowLists/SimpleAllowList.ts
@@ -99,7 +99,9 @@ export class SimpleAllowList extends DeployableTargetWithRBAC<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_SIMPLE_ALLOWLIST_BASE,
+    ...(import.meta.env?.VITE_SIMPLE_ALLOWLIST_BASE
+      ? { 31337: import.meta.env.VITE_SIMPLE_ALLOWLIST_BASE }
+      : {}),
     ...(SimpleAllowListBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/AllowLists/SimpleDenyList.ts
+++ b/packages/sdk/src/AllowLists/SimpleDenyList.ts
@@ -91,7 +91,9 @@ export class SimpleDenyList<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_SIMPLE_DENYLIST_BASE,
+    ...(import.meta.env?.VITE_SIMPLE_DENYLIST_BASE
+      ? { 31337: import.meta.env.VITE_SIMPLE_DENYLIST_BASE }
+      : {}),
     ...(SimpleDenyListBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -179,7 +179,9 @@ export const FEE_DENOMINATOR = 10000n;
  * @type {Record<number, Address>}
  */
 export const BOOST_CORE_ADDRESSES: Record<number, Address> = {
-  31337: import.meta.env.VITE_BOOST_CORE_ADDRESS,
+  ...(import.meta.env?.VITE_BOOST_CORE_ADDRESS
+    ? { 31337: import.meta.env.VITE_BOOST_CORE_ADDRESS }
+    : {}),
   ...(BoostCoreBases as Record<number, Address>),
 };
 

--- a/packages/sdk/src/BoostRegistry.ts
+++ b/packages/sdk/src/BoostRegistry.ts
@@ -48,7 +48,9 @@ export { boostRegistryAbi };
  * @type {Record<number, Address>}
  */
 export const BOOST_REGISTRY_ADDRESSES: Record<number, Address> = {
-  31337: import.meta.env.VITE_BOOST_REGISTRY_ADDRESS,
+  ...(import.meta.env?.VITE_BOOST_REGISTRY_ADDRESS
+    ? { 31337: import.meta.env.VITE_BOOST_REGISTRY_ADDRESS }
+    : {}),
   ...(BoostRegistryBases as Record<number, Address>),
 };
 

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -191,7 +191,9 @@ export class ManagedBudget extends DeployableTargetWithRBAC<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_MANAGED_BUDGET_BASE,
+    ...(import.meta.env?.VITE_MANAGED_BUDGET_BASE
+      ? { 31337: import.meta.env.VITE_MANAGED_BUDGET_BASE }
+      : {}),
     ...(ManagedBudgetBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Budgets/ManagedBudgetWithFees.ts
+++ b/packages/sdk/src/Budgets/ManagedBudgetWithFees.ts
@@ -132,7 +132,9 @@ export class ManagedBudgetWithFees extends DeployableTargetWithRBAC<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_MANAGED_BUDGET_WITH_FEES_BASE,
+    ...(import.meta.env?.VITE_MANAGED_BUDGET_WITH_FEES_BASE
+      ? { 31337: import.meta.env.VITE_MANAGED_BUDGET_WITH_FEES_BASE }
+      : {}),
     ...(ManagedBudgetWithFeesBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Budgets/ManagedBudgetWithFeesV2.ts
+++ b/packages/sdk/src/Budgets/ManagedBudgetWithFeesV2.ts
@@ -134,7 +134,9 @@ export class ManagedBudgetWithFeesV2 extends DeployableTargetWithRBAC<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_MANAGED_BUDGET_WITH_FEES_BASE,
+    ...(import.meta.env?.VITE_MANAGED_BUDGET_WITH_FEES_BASE
+      ? { 31337: import.meta.env.VITE_MANAGED_BUDGET_WITH_FEES_BASE }
+      : {}),
     ...(ManagedBudgetWithFeesV2Bases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Budgets/TransparentBudget.ts
+++ b/packages/sdk/src/Budgets/TransparentBudget.ts
@@ -82,7 +82,9 @@ export class TransparentBudget extends DeployableTargetWithRBAC<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_TRANSPARENT_BUDGET_BASE,
+    ...(import.meta.env?.VITE_TRANSPARENT_BUDGET_BASE
+      ? { 31337: import.meta.env.VITE_TRANSPARENT_BUDGET_BASE }
+      : {}),
     ...(TransparentBudgetBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -130,7 +130,9 @@ export class VestingBudget extends DeployableTargetWithRBAC<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_VESTING_BUDGET_BASE,
+    ...(import.meta.env?.VITE_VESTING_BUDGET_BASE
+      ? { 31337: import.meta.env.VITE_VESTING_BUDGET_BASE }
+      : {}),
   };
   /**
    * @inheritdoc

--- a/packages/sdk/src/Deployable/DeployableTarget.ts
+++ b/packages/sdk/src/Deployable/DeployableTarget.ts
@@ -64,9 +64,8 @@ export class DeployableTarget<
   public get isBase() {
     if (
       !!this.address &&
-      Object.values(this.bases).some((base) =>
-        // biome-ignore lint/style/noNonNullAssertion: won't evaluate this if address checked and defined above
-        isAddressEqual(this.address!, base),
+      Object.values(this.bases).some(
+        (base) => base && this.address && isAddressEqual(this.address, base),
       )
     )
       return true;

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -97,7 +97,9 @@ export class AllowListIncentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ALLOWLIST_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ALLOWLIST_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ALLOWLIST_INCENTIVE_BASE }
+      : {}),
     ...(AllowListIncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -156,7 +156,9 @@ export class CGDAIncentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_CGDA_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_CGDA_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_CGDA_INCENTIVE_BASE }
+      : {}),
     ...(CGDAIncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -130,7 +130,9 @@ export class ERC1155Incentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC1155_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ERC1155_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ERC1155_INCENTIVE_BASE }
+      : {}),
   };
   /**
    * @inheritdoc

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -124,7 +124,9 @@ export class ERC20Incentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ERC20_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE }
+      : {}),
     ...(ERC20IncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedIncentive.ts
@@ -118,7 +118,9 @@ export class ERC20PeggedIncentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ERC20_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE }
+      : {}),
     ...(ERC20PeggedIncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentive.ts
@@ -153,7 +153,9 @@ export class ERC20PeggedVariableCriteriaIncentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ERC20_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE }
+      : {}),
     ...(ERC20PeggedVariableCriteriaIncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentiveV2.ts
+++ b/packages/sdk/src/Incentives/ERC20PeggedVariableCriteriaIncentiveV2.ts
@@ -156,8 +156,12 @@ export class ERC20PeggedVariableCriteriaIncentiveV2 extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env
-      .VITE_ERC20_PEGGED_VARIABLE_CRITERIA_INCENTIVE_V2_BASE,
+    ...(import.meta.env?.VITE_ERC20_PEGGED_VARIABLE_CRITERIA_INCENTIVE_V2_BASE
+      ? {
+          31337: import.meta.env
+            .VITE_ERC20_PEGGED_VARIABLE_CRITERIA_INCENTIVE_V2_BASE,
+        }
+      : {}),
     ...(ERC20PeggedVariableCriteriaIncentiveV2Bases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentive.ts
@@ -128,7 +128,9 @@ export class ERC20VariableCriteriaIncentive extends ERC20VariableIncentive<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC20_VARIABLE_CRITERIA_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ERC20_VARIABLE_CRITERIA_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ERC20_VARIABLE_CRITERIA_INCENTIVE_BASE }
+      : {}),
     ...(ERC20VariableCriteriaIncentiveBases as Record<number, Address>),
   };
 

--- a/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableCriteriaIncentiveV2.ts
@@ -143,7 +143,11 @@ export class ERC20VariableCriteriaIncentiveV2 extends ERC20VariableIncentive<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC20_VARIABLE_CRITERIA_INCENTIVE_V2_BASE,
+    ...(import.meta.env?.VITE_ERC20_VARIABLE_CRITERIA_INCENTIVE_V2_BASE
+      ? {
+          31337: import.meta.env.VITE_ERC20_VARIABLE_CRITERIA_INCENTIVE_V2_BASE,
+        }
+      : {}),
     ...(ERC20VariableCriteriaIncentiveV2Bases as Record<number, Address>),
   };
 

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -113,7 +113,9 @@ export class ERC20VariableIncentive<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_ERC20_VARIABLE_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_ERC20_VARIABLE_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_ERC20_VARIABLE_INCENTIVE_BASE }
+      : {}),
     ...(ERC20VariableIncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -111,7 +111,9 @@ export class PointsIncentive extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_POINTS_INCENTIVE_BASE,
+    ...(import.meta.env?.VITE_POINTS_INCENTIVE_BASE
+      ? { 31337: import.meta.env.VITE_POINTS_INCENTIVE_BASE }
+      : {}),
     ...(PointsIncentiveBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Validators/LimitedSignerValidator.ts
+++ b/packages/sdk/src/Validators/LimitedSignerValidator.ts
@@ -316,7 +316,9 @@ export class LimitedSignerValidator extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_LIMITED_SIGNER_VALIDATOR_BASE,
+    ...(import.meta.env?.VITE_LIMITED_SIGNER_VALIDATOR_BASE
+      ? { 31337: import.meta.env.VITE_LIMITED_SIGNER_VALIDATOR_BASE }
+      : {}),
     ...(SignerValidatorBases as Record<number, Address>),
   };
   /**

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -309,7 +309,9 @@ export class SignerValidator extends DeployableTarget<
    * @type {Record<number, Address>}
    */
   public static override bases: Record<number, Address> = {
-    31337: import.meta.env.VITE_SIGNER_VALIDATOR_BASE,
+    ...(import.meta.env?.VITE_SIGNER_VALIDATOR_BASE
+      ? { 31337: import.meta.env.VITE_SIGNER_VALIDATOR_BASE }
+      : {}),
     ...(SignerValidatorBases as Record<number, Address>),
   };
   /**


### PR DESCRIPTION

- conditionally adds hardhat chainId (31337) to bases only if address is defined in the env file.
- fixes an issue where a crash would occur when calling `isBase()` with hardhat chain being undefined in the bases array.
- adds an additional guard to make sure both base and this.address are defined before calling `isAddressEqual`