### PR TITLE
[BOOST-5716] add sdk implementation for OffchainAccessList

### DIFF
--- a/.changeset/honest-maps-dream.md
+++ b/.changeset/honest-maps-dream.md
@@ -1,6 +1,7 @@
 ---
 "@boostxyz/evm": minor
 "@boostxyz/sdk": minor
+"@boostxyz/cli": minor
 ---
 
 add OffchainAccessList SDK implementation

--- a/.changeset/honest-maps-dream.md
+++ b/.changeset/honest-maps-dream.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+add OffchainAccessList SDK implementation

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,6 +1,7 @@
 import ContractActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/ContractAction.sol/ContractAction.json';
 import ERC721MintActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/ERC721MintAction.sol/ERC721MintAction.json';
 import EventActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
+import OffchainAccessListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/OffchainAccessList.sol/OffchainAccessList.json';
 import SimpleAllowListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/SimpleAllowList.sol/SimpleAllowList.json';
 import SimpleDenyListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/SimpleDenyList.sol/SimpleDenyList.json';
 import ManagedBudgetArtifact from '@boostxyz/evm/artifacts/contracts/budgets/ManagedBudget.sol/ManagedBudget.json';
@@ -28,6 +29,7 @@ import {
   LimitedSignerValidator,
   ManagedBudget,
   ManagedBudgetWithFees,
+  OffchainAccessList,
   PayableLimitedSignerValidator,
   PointsIncentive,
   SignerValidator,
@@ -47,6 +49,7 @@ export type DeployResult = {
   ERC721_MINT_ACTION_BASE: string;
   SIMPLE_ALLOWLIST_BASE: string;
   SIMPLE_DENYLIST_BASE: string;
+  OFFCHAIN_ACCESS_LIST_BASE: string;
   MANAGED_BUDGET_BASE: string;
   VESTING_BUDGET_BASE: string;
   ALLOWLIST_INCENTIVE_BASE: string;
@@ -144,6 +147,14 @@ export const deploy: Command<DeployResult> = async function deploy(
     deployContract(config, {
       abi: SimpleDenyListArtifact.abi,
       bytecode: SimpleDenyListArtifact.bytecode as Hex,
+      account,
+    }),
+  );
+  const offchainAccessListBase = await getDeployedContractAddress(
+    config,
+    deployContract(config, {
+      abi: OffchainAccessListArtifact.abi,
+      bytecode: OffchainAccessListArtifact.bytecode as Hex,
       account,
     }),
   );
@@ -293,6 +304,11 @@ export const deploy: Command<DeployResult> = async function deploy(
         [chainId]: simpleDenyListBase,
       };
     },
+    OffchainAccessList: class TOffchainAccessList extends OffchainAccessList {
+      public static override bases: Record<number, Address> = {
+        [chainId]: offchainAccessListBase,
+      };
+    },
     ManagedBudget: class TManagedBudget extends ManagedBudget {
       public static override bases: Record<number, Address> = {
         [chainId]: managedBudgetBase,
@@ -372,6 +388,7 @@ export const deploy: Command<DeployResult> = async function deploy(
     ERC721_MINT_ACTION_BASE: erc721MintActionBase,
     SIMPLE_ALLOWLIST_BASE: simpleAllowListBase,
     SIMPLE_DENYLIST_BASE: simpleDenyListBase,
+    OFFCHAIN_ACCESS_LIST_BASE: offchainAccessListBase,
     MANAGED_BUDGET_BASE: managedBudgetBase,
     VESTING_BUDGET_BASE: vestingBudgetBase,
     ALLOWLIST_INCENTIVE_BASE: allowListIncentiveBase,

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -23,6 +23,7 @@ import {
   type ManagedBudgetPayload,
   type ManagedBudgetWithFeesV2,
   type ManagedBudgetWithFeesV2Payload,
+  type OffchainAccessListPayload,
   type PayableLimitedSignerValidatorPayload,
   type PointsIncentivePayload,
   PrimitiveType,
@@ -344,7 +345,9 @@ export type BoostConfig = {
     | Identifiable<PayableLimitedSignerValidatorPayload>
   >;
   allowList: DeployablePayloadOrAddress<
-    Identifiable<SimpleDenyListPayload> | Identifiable<SimpleAllowListPayload>
+    | Identifiable<SimpleDenyListPayload>
+    | Identifiable<SimpleAllowListPayload>
+    | Identifiable<OffchainAccessListPayload>
   >;
   incentives: (
     | Identifiable<AllowListIncentivePayload>
@@ -428,6 +431,13 @@ export const SimpleAllowListSchema = z.object({
   type: z.literal('SimpleAllowList'),
   owner: AddressSchema,
   allowed: z.array(AddressSchema),
+});
+
+export const OffchainAccessListSchema = z.object({
+  type: z.literal('OffchainAccessList'),
+  owner: AddressSchema,
+  allowlistIds: z.array(z.string()),
+  denylistIds: z.array(z.string()),
 });
 
 export const AllowListIncentiveSchema = z.object({
@@ -522,7 +532,12 @@ export const BoostSeedConfigSchema = z.object({
     ])
     .optional(),
   allowList: z
-    .union([AddressSchema, SimpleDenyListSchema, SimpleAllowListSchema])
+    .union([
+      AddressSchema,
+      SimpleDenyListSchema,
+      SimpleAllowListSchema,
+      OffchainAccessListSchema,
+    ])
     .optional(),
   incentives: z.array(
     z.union([
@@ -555,6 +570,8 @@ async function getAllowList(
       return core.SimpleAllowList(allowList as SimpleAllowListPayload);
     case 'SimpleDenyList':
       return core.SimpleDenyList(allowList as SimpleDenyListPayload);
+    case 'OffchainAccessList':
+      return core.OffchainAccessList(allowList as OffchainAccessListPayload);
     default:
       throw new Error('unusupported AllowList: ' + allowList);
   }

--- a/packages/sdk/src/AllowLists/AllowList.ts
+++ b/packages/sdk/src/AllowLists/AllowList.ts
@@ -1,5 +1,6 @@
 import { aAllowListAbi } from '@boostxyz/evm';
 import {
+  AOffchainAccessList,
   ASimpleAllowList,
   ASimpleDenyList,
 } from '@boostxyz/evm/deploys/componentInterfaces.json';
@@ -8,11 +9,12 @@ import type { Address, Hex } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
 import { InvalidComponentInterfaceError } from '../errors';
 import type { ReadParams } from '../utils';
+import { OffchainAccessList } from './OffchainAccessList';
 import { OpenAllowList } from './OpenAllowList';
 import { SimpleAllowList } from './SimpleAllowList';
 import { SimpleDenyList } from './SimpleDenyList';
 
-export { OpenAllowList, SimpleAllowList, SimpleDenyList };
+export { OffchainAccessList, OpenAllowList, SimpleAllowList, SimpleDenyList };
 
 /**
  * A union type representing all valid protocol AllowList implementations
@@ -20,16 +22,21 @@ export { OpenAllowList, SimpleAllowList, SimpleDenyList };
  * @export
  * @typedef {AllowList}
  */
-export type AllowList = OpenAllowList | SimpleAllowList | SimpleDenyList;
+export type AllowList =
+  | OffchainAccessList
+  | OpenAllowList
+  | SimpleAllowList
+  | SimpleDenyList;
 
 /**
  * A map of AllowList component interfaces to their constructors.
  *
- * @type {{ "0x2bc9016b": SimpleAllowList; "0x9d585f63": SimpleDenyList; }}
+ * @type {{ "0x1392d798": SimpleAllowList; "0x3d30a22c": SimpleDenyList; "0x2a6b3c38": OffchainAccessList; }}
  */
 export const AllowListByComponentInterface = {
   [ASimpleAllowList as Hex]: SimpleAllowList,
   [ASimpleDenyList as Hex]: SimpleDenyList,
+  [AOffchainAccessList as Hex]: OffchainAccessList,
 };
 
 /**
@@ -61,5 +68,8 @@ export async function allowListFromAddress(
       interfaceId as Hex,
     );
   }
-  return new Ctor(options, address) as SimpleDenyList | SimpleAllowList;
+  return new Ctor(options, address) as
+    | SimpleDenyList
+    | SimpleAllowList
+    | OffchainAccessList;
 }

--- a/packages/sdk/src/AllowLists/OffchainAccessList.test.ts
+++ b/packages/sdk/src/AllowLists/OffchainAccessList.test.ts
@@ -1,0 +1,154 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { isAddress } from 'viem';
+import { beforeAll, describe, expect, test } from 'vitest';
+import {
+  type Fixtures,
+  defaultOptions,
+  deployFixtures,
+} from '@boostxyz/test/helpers';
+import { OffchainAccessList } from './OffchainAccessList';
+
+let fixtures: Fixtures;
+
+beforeAll(async () => {
+  fixtures = await loadFixture(deployFixtures(defaultOptions));
+});
+
+function freshOffchainAccessList(fixtures: Fixtures) {
+  return function freshOffchainAccessList() {
+    return fixtures.registry.initialize(
+      crypto.randomUUID(),
+      fixtures.core.OffchainAccessList({
+        owner: defaultOptions.account.address,
+        allowlistIds: ['allow-1', 'allow-2'],
+        denylistIds: ['deny-1', 'deny-2'],
+      }),
+    );
+  };
+}
+
+describe('OffchainAccessList', () => {
+  test('can successfully be deployed', async () => {
+    const accessList = new OffchainAccessList(defaultOptions, {
+      owner: defaultOptions.account.address,
+      allowlistIds: [],
+      denylistIds: [],
+    });
+    // @ts-expect-error - deploy is protected
+    await accessList.deploy();
+    expect(isAddress(accessList.assertValidAddress())).toBe(true);
+  });
+
+  test('can get owner', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    expect(await accessList.owner()).toBe(defaultOptions.account.address);
+  });
+
+  // TODO: Add isAllowed tests once off-chain API integration is implemented
+  // test('can check if address is allowed via off-chain API', async () => {
+  //   const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+  //   expect(await accessList.isAllowed(defaultOptions.account.address)).toBe(true);
+  //   expect(await accessList.isAllowed(zeroAddress)).toBe(false);
+  // });
+
+  test('can get allowlist IDs', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    const allowlistIds = await accessList.getAllowlistIds();
+    expect(allowlistIds).toEqual(['allow-1', 'allow-2']);
+  });
+
+  test('can get denylist IDs', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    const denylistIds = await accessList.getDenylistIds();
+    expect(denylistIds).toEqual(['deny-1', 'deny-2']);
+  });
+
+  test('can set allowlist IDs', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    await accessList.setAllowlistIds(['new-allow-1', 'new-allow-2', 'new-allow-3']);
+    const allowlistIds = await accessList.getAllowlistIds();
+    expect(allowlistIds).toEqual(['new-allow-1', 'new-allow-2', 'new-allow-3']);
+  });
+
+  test('can set denylist IDs', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    await accessList.setDenylistIds(['new-deny-1', 'new-deny-2', 'new-deny-3']);
+    const denylistIds = await accessList.getDenylistIds();
+    expect(denylistIds).toEqual(['new-deny-1', 'new-deny-2', 'new-deny-3']);
+  });
+
+  test('can add allowlist ID', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    await accessList.addAllowlistId('new-allow-id');
+    const allowlistIds = await accessList.getAllowlistIds();
+    expect(allowlistIds).toContain('new-allow-id');
+    expect(allowlistIds).toHaveLength(3);
+  });
+
+  test('can add denylist ID', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    await accessList.addDenylistId('new-deny-id');
+    const denylistIds = await accessList.getDenylistIds();
+    expect(denylistIds).toContain('new-deny-id');
+    expect(denylistIds).toHaveLength(3);
+  });
+
+  test('can remove allowlist ID', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    await accessList.removeAllowlistId('allow-1');
+    const allowlistIds = await accessList.getAllowlistIds();
+    expect(allowlistIds).not.toContain('allow-1');
+    expect(allowlistIds).toContain('allow-2');
+    expect(allowlistIds).toHaveLength(1);
+  });
+
+  test('can remove denylist ID', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    await accessList.removeDenylistId('deny-1');
+    const denylistIds = await accessList.getDenylistIds();
+    expect(denylistIds).not.toContain('deny-1');
+    expect(denylistIds).toContain('deny-2');
+    expect(denylistIds).toHaveLength(1);
+  });
+
+  test('can check if allowlist ID exists', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    expect(await accessList.hasAllowlistId('allow-1')).toBe(true);
+    expect(await accessList.hasAllowlistId('allow-2')).toBe(true);
+    expect(await accessList.hasAllowlistId('nonexistent')).toBe(false);
+  });
+
+  test('can check if denylist ID exists', async () => {
+    const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+    expect(await accessList.hasDenylistId('deny-1')).toBe(true);
+    expect(await accessList.hasDenylistId('deny-2')).toBe(true);
+    expect(await accessList.hasDenylistId('nonexistent')).toBe(false);
+  });
+
+  test('can handle empty allowlist and denylist', async () => {
+    const accessList = new OffchainAccessList(defaultOptions, {
+      owner: defaultOptions.account.address,
+      allowlistIds: [],
+      denylistIds: [],
+    });
+    // @ts-expect-error - deploy is protected
+    await accessList.deploy();
+    
+    const allowlistIds = await accessList.getAllowlistIds();
+    const denylistIds = await accessList.getDenylistIds();
+    
+    expect(allowlistIds).toEqual([]);
+    expect(denylistIds).toEqual([]);
+    expect(await accessList.hasAllowlistId('nonexistent')).toBe(false);
+    expect(await accessList.hasDenylistId('nonexistent')).toBe(false);
+  });
+
+  // TODO: Add test for off-chain access behavior once API integration is implemented
+  // test('can check off-chain access behavior', async () => {
+  //   const accessList = await loadFixture(freshOffchainAccessList(fixtures));
+  //   
+  //   // Should check against off-chain allowlist/denylist APIs
+  //   expect(await accessList.isAllowed(defaultOptions.account.address)).toBe(true);
+  //   expect(await accessList.isAllowed(zeroAddress)).toBe(false);
+  // });
+});

--- a/packages/sdk/src/AllowLists/OffchainAccessList.ts
+++ b/packages/sdk/src/AllowLists/OffchainAccessList.ts
@@ -150,11 +150,10 @@ export class OffchainAccessList extends DeployableTargetWithRBAC<
    * @returns {Promise<boolean>} - True if the user is allowed
    */
   public isAllowed(_address: Address, _params?: ReadParams) {
-    // TODO: Make API calls to check address against these lists
-    // const allowlistIds = await this.getAllowlistIds();
-    // const denylistIds = await this.getDenylistIds();
-    // return await checkOffchainAccess(address, allowlistIds, denylistIds);
-    throw new Error('isAllowed() not implemented for OffchainAccessList');
+    // TODO: check address against offchain allowlist/denylist using api calls
+    throw new Error(
+      'isAllowed() not available for OffchainAccessList, implementation should be done offchain',
+    );
   }
 
   /**

--- a/packages/sdk/src/AllowLists/OffchainAccessList.ts
+++ b/packages/sdk/src/AllowLists/OffchainAccessList.ts
@@ -1,0 +1,535 @@
+import {
+  offchainAccessListAbi,
+  readOffchainAccessListGetAllowListIds,
+  readOffchainAccessListGetDenyListIds,
+  readOffchainAccessListHasAllowListId,
+  readOffchainAccessListHasDenyListId,
+  readOffchainAccessListOwner,
+  simulateOffchainAccessListAddAllowListId,
+  simulateOffchainAccessListAddDenyListId,
+  simulateOffchainAccessListRemoveAllowListId,
+  simulateOffchainAccessListRemoveDenyListId,
+  simulateOffchainAccessListSetAllowListIds,
+  simulateOffchainAccessListSetDenyListIds,
+  writeOffchainAccessListAddAllowListId,
+  writeOffchainAccessListAddDenyListId,
+  writeOffchainAccessListRemoveAllowListId,
+  writeOffchainAccessListRemoveDenyListId,
+  writeOffchainAccessListSetAllowListIds,
+  writeOffchainAccessListSetDenyListIds,
+} from '@boostxyz/evm';
+import { bytecode } from '@boostxyz/evm/artifacts/contracts/allowlists/OffchainAccessList.sol/OffchainAccessList.json';
+import { getAccount } from '@wagmi/core';
+import {
+  type Address,
+  type ContractEventName,
+  type Hex,
+  encodeAbiParameters,
+  zeroAddress,
+} from 'viem';
+import { OffchainAccessList as OffchainAccessListBases } from '../../dist/deployments.json';
+import type {
+  DeployableOptions,
+  GenericDeployableParams,
+} from '../Deployable/Deployable';
+import { DeployableTargetWithRBAC } from '../Deployable/DeployableTargetWithRBAC';
+import { DeployableUnknownOwnerProvidedError } from '../errors';
+import {
+  type GenericLog,
+  type ReadParams,
+  RegistryType,
+  type WriteParams,
+} from '../utils';
+
+export { offchainAccessListAbi };
+
+/**
+ * Object representation of a {@link OffchainAccessList} initialization payload.
+ *
+ * @export
+ * @interface OffchainAccessListPayload
+ * @typedef {OffchainAccessListPayload}
+ */
+export interface OffchainAccessListPayload {
+  /**
+   * The access list's owner
+   *
+   * @type {Address}
+   */
+  owner: Address;
+  /**
+   * List of off-chain allowlist IDs.
+   *
+   * @type {string[]}
+   */
+  allowlistIds: string[];
+  /**
+   * List of off-chain denylist IDs.
+   *
+   * @type {string[]}
+   */
+  denylistIds: string[];
+}
+
+/**
+ * A generic `viem.Log` event with support for `OffchainAccessList` event types.
+ *
+ * @export
+ * @typedef {OffchainAccessListLog}
+ * @template {ContractEventName<typeof offchainAccessListAbi>} [event=ContractEventName<
+ *     typeof offchainAccessListAbi
+ *   >]
+ */
+export type OffchainAccessListLog<
+  event extends ContractEventName<
+    typeof offchainAccessListAbi
+  > = ContractEventName<typeof offchainAccessListAbi>,
+> = GenericLog<typeof offchainAccessListAbi, event>;
+
+/**
+ * An AllowList that links on-chain boosts to off-chain access lists stored in a database.
+ * This implementation always allows everyone (returns true) but stores references to off-chain allowlist and denylist IDs.
+ *
+ * @export
+ * @class OffchainAccessList
+ * @typedef {OffchainAccessList}
+ * @extends {DeployableTargetWithRBAC<OffchainAccessListPayload>}
+ */
+export class OffchainAccessList extends DeployableTargetWithRBAC<
+  OffchainAccessListPayload,
+  typeof offchainAccessListAbi
+> {
+  public override readonly abi = offchainAccessListAbi;
+  /**
+   * @inheritdoc
+   *
+   * @public
+   * @static
+   * @type {Record<number, Address>}
+   */
+  public static override bases: Record<number, Address> = {
+    ...(import.meta.env?.VITE_OFFCHAIN_ACCESS_LIST_BASE
+      ? { 31337: import.meta.env.VITE_OFFCHAIN_ACCESS_LIST_BASE }
+      : {}),
+    ...(OffchainAccessListBases as Record<number, Address>),
+  };
+  /**
+   * @inheritdoc
+   *
+   * @public
+   * @static
+   * @type {RegistryType}
+   */
+  public static override registryType: RegistryType = RegistryType.ALLOW_LIST;
+
+  /**
+   * Retrieves the owner
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<Address>} - The address of the owner
+   */
+  public async owner(params?: ReadParams): Promise<Address> {
+    return await readOffchainAccessListOwner(this._config, {
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+      address: this.assertValidAddress(),
+      args: [],
+    });
+  }
+
+  /**
+   * Check if a user is authorized based on off-chain allowlists/denylists
+   *
+   * @public
+   * @async
+   * @param {Address} address - The address of the user
+   * @param {?ReadParams} [params]
+   * @returns {Promise<boolean>} - True if the user is allowed
+   */
+  public isAllowed(_address: Address, _params?: ReadParams) {
+    // TODO: Make API calls to check address against these lists
+    // const allowlistIds = await this.getAllowlistIds();
+    // const denylistIds = await this.getDenylistIds();
+    // return await checkOffchainAccess(address, allowlistIds, denylistIds);
+    throw new Error('isAllowed() not implemented for OffchainAccessList');
+  }
+
+  /**
+   * Get all allowlist IDs
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<string[]>} - Array of allowlist IDs
+   */
+  public async getAllowlistIds(params?: ReadParams) {
+    return await readOffchainAccessListGetAllowListIds(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * Get all denylist IDs
+   *
+   * @public
+   * @async
+   * @param {?ReadParams} [params]
+   * @returns {Promise<string[]>} - Array of denylist IDs
+   */
+  public async getDenylistIds(params?: ReadParams) {
+    return await readOffchainAccessListGetDenyListIds(this._config, {
+      address: this.assertValidAddress(),
+      args: [],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * Set allowlist IDs, replacing all existing ones. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string[]} ids - The new allowlist IDs
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async setAllowlistIds(ids: string[], params?: WriteParams) {
+    return await this.awaitResult(this.setAllowlistIdsRaw(ids, params));
+  }
+
+  /**
+   * Set allowlist IDs, replacing all existing ones. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string[]} ids - The new allowlist IDs
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async setAllowlistIdsRaw(ids: string[], params?: WriteParams) {
+    const { request, result } = await simulateOffchainAccessListSetAllowListIds(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [ids],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOffchainAccessListSetAllowListIds(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Set denylist IDs, replacing all existing ones. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string[]} ids - The new denylist IDs
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async setDenylistIds(ids: string[], params?: WriteParams) {
+    return await this.awaitResult(this.setDenylistIdsRaw(ids, params));
+  }
+
+  /**
+   * Set denylist IDs, replacing all existing ones. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string[]} ids - The new denylist IDs
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async setDenylistIdsRaw(ids: string[], params?: WriteParams) {
+    const { request, result } = await simulateOffchainAccessListSetDenyListIds(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [ids],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOffchainAccessListSetDenyListIds(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Add a single allowlist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The allowlist ID to add
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async addAllowlistId(id: string, params?: WriteParams) {
+    return await this.awaitResult(this.addAllowlistIdRaw(id, params));
+  }
+
+  /**
+   * Add a single allowlist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The allowlist ID to add
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async addAllowlistIdRaw(id: string, params?: WriteParams) {
+    const { request, result } = await simulateOffchainAccessListAddAllowListId(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [id],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOffchainAccessListAddAllowListId(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Add a single denylist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The denylist ID to add
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async addDenylistId(id: string, params?: WriteParams) {
+    return await this.awaitResult(this.addDenylistIdRaw(id, params));
+  }
+
+  /**
+   * Add a single denylist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The denylist ID to add
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async addDenylistIdRaw(id: string, params?: WriteParams) {
+    const { request, result } = await simulateOffchainAccessListAddDenyListId(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [id],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeOffchainAccessListAddDenyListId(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Remove a single allowlist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The allowlist ID to remove
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async removeAllowlistId(id: string, params?: WriteParams) {
+    return await this.awaitResult(this.removeAllowlistIdRaw(id, params));
+  }
+
+  /**
+   * Remove a single allowlist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The allowlist ID to remove
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async removeAllowlistIdRaw(id: string, params?: WriteParams) {
+    const { request, result } =
+      await simulateOffchainAccessListRemoveAllowListId(this._config, {
+        address: this.assertValidAddress(),
+        args: [id],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      });
+    const hash = await writeOffchainAccessListRemoveAllowListId(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Remove a single denylist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The denylist ID to remove
+   * @param {?WriteParams} [params]
+   * @returns {Promise<void>}
+   */
+  public async removeDenylistId(id: string, params?: WriteParams) {
+    return await this.awaitResult(this.removeDenylistIdRaw(id, params));
+  }
+
+  /**
+   * Remove a single denylist ID. This function can only be called by authorized users.
+   *
+   * @public
+   * @async
+   * @param {string} id - The denylist ID to remove
+   * @param {?WriteParams} [params]
+   * @returns {Promise<{ hash: `0x${string}`; result: void; }>}
+   */
+  public async removeDenylistIdRaw(id: string, params?: WriteParams) {
+    const { request, result } =
+      await simulateOffchainAccessListRemoveDenyListId(this._config, {
+        address: this.assertValidAddress(),
+        args: [id],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      });
+    const hash = await writeOffchainAccessListRemoveDenyListId(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  /**
+   * Check if an allowlist ID exists
+   *
+   * @public
+   * @async
+   * @param {string} id - The allowlist ID to check
+   * @param {?ReadParams} [params]
+   * @returns {Promise<boolean>} - True if the ID exists
+   */
+  public async hasAllowlistId(
+    id: string,
+    params?: ReadParams,
+  ): Promise<boolean> {
+    return await readOffchainAccessListHasAllowListId(this._config, {
+      address: this.assertValidAddress(),
+      args: [id],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * Check if a denylist ID exists
+   *
+   * @public
+   * @async
+   * @param {string} id - The denylist ID to check
+   * @param {?ReadParams} [params]
+   * @returns {Promise<boolean>} - True if the ID exists
+   */
+  public async hasDenylistId(
+    id: string,
+    params?: ReadParams,
+  ): Promise<boolean> {
+    return await readOffchainAccessListHasDenyListId(this._config, {
+      address: this.assertValidAddress(),
+      args: [id],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+  }
+
+  /**
+   * @inheritdoc
+   *
+   * @public
+   * @param {?OffchainAccessListPayload} [_payload]
+   * @param {?DeployableOptions} [_options]
+   * @returns {GenericDeployableParams}
+   */
+  public override buildParameters(
+    _payload?: OffchainAccessListPayload,
+    _options?: DeployableOptions,
+  ): GenericDeployableParams {
+    const [payload, options] = this.validateDeploymentConfig(
+      _payload,
+      _options,
+    );
+    if (!payload.owner || payload.owner === zeroAddress) {
+      const owner = options.account
+        ? options.account.address
+        : options.config
+          ? getAccount(options.config).address
+          : this._account?.address;
+      if (owner) {
+        payload.owner = owner;
+      } else {
+        throw new DeployableUnknownOwnerProvidedError();
+      }
+    }
+    return {
+      abi: offchainAccessListAbi,
+      bytecode: bytecode as Hex,
+      args: [prepareOffchainAccessListPayload(payload)],
+      ...this.optionallyAttachAccount(options.account),
+    };
+  }
+}
+
+/**
+ * Given a {@link OffchainAccessListPayload}, properly encode the initialization payload.
+ *
+ * @param {OffchainAccessListPayload} param0
+ * @param {Address} param0.owner - The access list's owner
+ * @param {string[]} param0.allowlistIds - List of off-chain allowlist IDs
+ * @param {string[]} param0.denylistIds - List of off-chain denylist IDs
+ * @returns {Hex}
+ */
+export function prepareOffchainAccessListPayload({
+  owner,
+  allowlistIds,
+  denylistIds,
+}: OffchainAccessListPayload) {
+  return encodeAbiParameters(
+    [
+      { type: 'address', name: 'owner' },
+      { type: 'string[]', name: 'allowlistIds' },
+      { type: 'string[]', name: 'denylistIds' },
+    ],
+    [owner, allowlistIds, denylistIds],
+  );
+}

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -50,6 +50,10 @@ import { BoostCore as BoostCoreBases } from '../dist/deployments.json';
 import { type Action, actionFromAddress } from './Actions/Action';
 import { EventAction, type EventActionPayload } from './Actions/EventAction';
 import { type AllowList, allowListFromAddress } from './AllowLists/AllowList';
+import {
+  OffchainAccessList,
+  type OffchainAccessListPayload,
+} from './AllowLists/OffchainAccessList';
 import { OpenAllowList } from './AllowLists/OpenAllowList';
 import {
   SimpleAllowList,
@@ -1714,6 +1718,28 @@ export class BoostCore extends Deployable<
     isBase?: boolean,
   ) {
     return new SimpleDenyList(
+      { config: this._config, account: this._account },
+      options,
+      isBase,
+    );
+  }
+  /**
+   * Bound {@link OffchainAccessList} constructor that reuses the same configuration as the Boost Core instance.
+   *
+   * @example
+   * ```ts
+   * const list = core.OffchainAccessList('0x') // is roughly equivalent to
+   * const list = new OffchainAccessList({ config: core._config, account: core._account }, '0x')
+   * ```
+   * @param {DeployablePayloadOrAddress<OffchainAccessListPayload>} options
+   * @param {?boolean} [isBase]
+   * @returns {OffchainAccessList}
+   */
+  OffchainAccessList(
+    options: DeployablePayloadOrAddress<OffchainAccessListPayload>,
+    isBase?: boolean,
+  ) {
+    return new OffchainAccessList(
       { config: this._config, account: this._account },
       options,
       isBase,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,7 @@ export * from './Actions/EventAction';
 // AllowLists
 
 export * from './AllowLists/AllowList';
+export * from './AllowLists/OffchainAccessList';
 export * from './AllowLists/SimpleAllowList';
 export * from './AllowLists/SimpleDenyList';
 

--- a/test/src/helpers.ts
+++ b/test/src/helpers.ts
@@ -7,6 +7,7 @@ import {
   writePointsInitialize,
 } from '@boostxyz/evm';
 import EventActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
+import OffchainAccessListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/OffchainAccessList.sol/OffchainAccessList.json';
 import SimpleAllowListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/SimpleAllowList.sol/SimpleAllowList.json';
 import SimpleDenyListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/SimpleDenyList.sol/SimpleDenyList.json';
 import ManagedBudgetArtifact from '@boostxyz/evm/artifacts/contracts/budgets/ManagedBudget.sol/ManagedBudget.json';
@@ -72,6 +73,8 @@ import {
   type ManagedBudgetWithFeesPayload,
   ManagedBudgetWithFeesV2,
   type ManagedBudgetWithFeesV2Payload,
+  OffchainAccessList,
+  type OffchainAccessListPayload,
   OpenAllowList,
   PayableLimitedSignerValidator,
   type PayableLimitedSignerValidatorPayload,
@@ -254,6 +257,14 @@ export function deployFixtures(
       deployContract(config, {
         abi: SimpleDenyListArtifact.abi,
         bytecode: SimpleDenyListArtifact.bytecode as Hex,
+        account,
+      }),
+    );
+    const offchainAccessListBase = await getDeployedContractAddress(
+      config,
+      deployContract(config, {
+        abi: OffchainAccessListArtifact.abi,
+        bytecode: OffchainAccessListArtifact.bytecode as Hex,
         account,
       }),
     );
@@ -445,6 +456,11 @@ export function deployFixtures(
           [chainId]: simpleDenyListBase,
         };
       },
+      OffchainAccessList: class TOffchainAccessList extends OffchainAccessList {
+        public static override bases: Record<number, Address> = {
+          [chainId]: offchainAccessListBase,
+        };
+      },
       // SimpleBudget: class TSimpleBudget extends SimpleBudget {
       //   public static override bases: Record<number, Address> = {
       //     [chainId]: simpleBudgetBase,
@@ -543,6 +559,7 @@ export function deployFixtures(
       SimpleAllowList: typeof SimpleAllowList;
       SimpleDenyList: typeof SimpleDenyList;
       OpenAllowList: typeof OpenAllowList;
+      OffchainAccessList: typeof OffchainAccessList;
       // SimpleBudget: typeof SimpleBudget;
       ManagedBudget: typeof ManagedBudget;
       ManagedBudgetWithFees: typeof ManagedBudgetWithFees;
@@ -642,6 +659,16 @@ export function deployFixtures(
         return new bases.OpenAllowList(
           { config: this._config, account: this._account },
           undefined,
+          isBase,
+        );
+      }
+      override OffchainAccessList(
+        options: DeployablePayloadOrAddress<OffchainAccessListPayload>,
+        isBase?: boolean,
+      ) {
+        return new bases.OffchainAccessList(
+          { config: this._config, account: this._account },
+          options,
           isBase,
         );
       }


### PR DESCRIPTION
### Description
- adds SDK implementation for OffchainAccessList

**TODO:**
- implement `isAllowed` once we have a proper api setup so we can check if a user has access based on the offchain access list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced OffchainAccessList, enabling management of allowlists and denylists linked to off-chain data.
  * Added methods for deploying, updating, and querying allowlist and denylist IDs, as well as retrieving ownership information.
  * OffchainAccessList is now accessible through the SDK, BoostCore, CLI deployment, and seed commands.

* **Tests**
  * Added comprehensive test coverage for OffchainAccessList functionalities, including list management and ownership.

* **Chores**
  * Updated test fixtures, SDK exports, CLI deployment scripts, and configuration schemas to support OffchainAccessList integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->