### PR TITLE
[BOOST-5790] add tuple support for claimant in sdk

### DIFF
--- a/.changeset/hungry-shirts-scream.md
+++ b/.changeset/hungry-shirts-scream.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+add tuple support for claimant

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -2011,7 +2011,7 @@ export function isCriteriaFieldIndexTuple(fieldIndex: number): boolean {
  * Helper function to check if a claimant fieldIndex represents tuple access.
  *
  * @param {number} fieldIndex - The field index to check
- * @returns {boolean} - True if it's a tuple index (32-254), false for direct access (0-31)
+ * @returns {boolean} - True if it's a tuple index, false for direct access
  */
 export function isClaimantFieldIndexTuple(fieldIndex: number): boolean {
   return isCriteriaFieldIndexTuple(fieldIndex);


### PR DESCRIPTION
### Description
- add support for single level tuples for claimant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claimant resolution now supports nested tuple fields in events and function arguments.
  - Tuple index encoding added to target nested values while keeping single-index behavior.
  - Ability to extract scalar values from nested tuples for incentive criteria.
  - Improved validation and safeguards for invalid or out-of-bounds tuple access.

- **Tests**
  - Expanded coverage for tuple-based claimant access, edge cases, and mixed structures.

- **Chores**
  - Prepared a minor SDK release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->