### PR TITLE
[BOOST-5830] add targetContract check in action validation

### DIFF
--- a/.changeset/beige-radios-cry.md
+++ b/.changeset/beige-radios-cry.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+add targetContract check in action validation

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -819,6 +819,13 @@ export class EventAction extends DeployableTarget<
 
     // Check each log
     for (let log of logs) {
+      // Log address must match the target contract. Zero address is a wildcard.
+      if (
+        actionStep.targetContract !== zeroAddress &&
+        !isAddressEqual(log.address, actionStep.targetContract)
+      ) {
+        continue;
+      }
       // parse out final (scalar) field from the log args
       try {
         if (!Array.isArray(log.args)) {
@@ -999,6 +1006,14 @@ export class EventAction extends DeployableTarget<
     transaction: Transaction,
     params: Pick<ValidateActionStepParams, 'abiItem' | 'knownSignatures'>,
   ) {
+    // Log address must match the target contract. Zero address is a wildcard.
+    if (
+      actionStep.targetContract !== zeroAddress &&
+      (!transaction.to ||
+        !isAddressEqual(transaction.to, actionStep.targetContract))
+    ) {
+      return false;
+    }
     const criteria = actionStep.actionParameter;
     const signature = actionStep.signature;
 
@@ -1389,7 +1404,12 @@ export class EventAction extends DeployableTarget<
     if (!logs.length) return filteredLogs;
 
     for (let log of logs) {
-      if (!isAddressEqual(log.address, actionStep.targetContract)) continue;
+      // Log address must match the target contract. Zero address is a wildcard.
+      if (
+        actionStep.targetContract !== zeroAddress &&
+        !isAddressEqual(log.address, actionStep.targetContract)
+      )
+        continue;
 
       try {
         if (!Array.isArray(log.args)) {


### PR DESCRIPTION
### Description
- adds a check to make sure the log address (or the to address for functions) matches the provided targetContract in the actionStep
- allows this check to be bypassed by using zeroAddress as the targetContract


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved event and transaction validation to enforce target contract address matching, reducing false positives while preserving wildcard behavior for unspecified targets.

- Chores
  - Updated an internal dependency reference with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->