### PR TITLE
[ADHOC] filter decoded logs using action step signature

### DIFF
--- a/.changeset/early-keys-sort.md
+++ b/.changeset/early-keys-sort.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+use actionStep signature to filter decoded logs

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -777,7 +777,7 @@ export class EventAction extends DeployableTarget<
       }
 
       const decodedLogs = receipt.logs
-        .filter((log) => log.topics[0] === toEventSelector(event))
+        .filter((log) => log.topics[0] === signature)
         .map((log) => decodeAndReorderLogArgs(event, log));
 
       return this.isActionEventValid(actionStep, decodedLogs, event);


### PR DESCRIPTION
### Description
- filters decoded logs using the action step signature instead of hashing the AbiEvent object. This allows us to work with event signatures for events that do not have an available abi.

See screenshot for example. We can derive the types from this and create a pseudo abi, but when you use `toEventSignature` the hash is the result of the event name + the param types. Since we do not know the event name in this case we cannot derive the correct hash, but since we know what the hash is already we can use it directly.

<img width="1378" height="374" alt="CleanShot 2025-10-06 at 20 56 26@2x" src="https://github.com/user-attachments/assets/8de7d343-31db-47fc-9a71-4bfb0c4b1e03" />

