### PR TITLE
[ADHOC] SDK release 8.1.0

### DIFF
--- a/.changeset/light-cheetahs-notice.md
+++ b/.changeset/light-cheetahs-notice.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+Add new chains Arbitrum, Ethereum and HyperEVM

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "agora-vote": "1.0.1-alpha.3",
@@ -13,5 +13,9 @@
     "@boostxyz/signatures": "1.3.0",
     "@boostxyz/test": "1.0.1-alpha.3"
   },
-  "changesets": ["rude-owls-divide", "three-readers-deny", "three-swans-prove"]
+  "changesets": [
+    "rude-owls-divide",
+    "three-readers-deny",
+    "three-swans-prove"
+  ]
 }


### PR DESCRIPTION
Promotes packages from canary pre-release versions to stable releases, finalizing changes that have been validated in the pre-release cycle.

### Version Updates

- **@boostxyz/sdk**: 8.1.0-canary.2 → 8.1.0
- **@boostxyz/evm**: 8.1.0 → 8.2.0
- **@boostxyz/cli**: 7.0.3-canary.2 → 7.0.3

### Changes Included

**SDK (8.1.0)**
- Validates action steps for the same signature/target contract as groups
- Fixes log reorder bug for viem versions > 2.30.6
- Updates default validator

**EVM (8.2.0)**
- Adds Arbitrum, Mainnet, and HyperEVM to supported chains

### Cleanup

- Removes pre-release configuration and changeset files as they've been incorporated into stable releases
- Updates changelog entries to reflect stable version releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to transition from pre-release mode to standard release mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->