### PR TITLE
[BOOST-6574] Enforce commitment constraints and root immutability after finalization

### DIFF
--- a/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
+++ b/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
@@ -231,7 +231,10 @@ contract TimeBasedIncentiveCampaign is Initializable, IClaw {
         if (cumulativeAmount <= alreadyClaimed) revert NothingToClaim();
         amount = cumulativeAmount - alreadyClaimed;
 
-        // The declared commitment is a hard ceiling on outflow
+        // The declared commitment is a hard ceiling on any single entitlement and on
+        // total outflow. The first check bounds both addends of the second to
+        // totalCommitted, so the addition cannot overflow.
+        if (cumulativeAmount > totalCommitted) revert ClaimExceedsCommitment();
         if (totalClaimed + amount > totalCommitted) revert ClaimExceedsCommitment();
 
         claimed[user] = cumulativeAmount;

--- a/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
+++ b/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
@@ -191,11 +191,17 @@ contract TimeBasedIncentiveCampaign is Initializable, IClaw {
     /// @param root The new merkle root
     /// @param totalCommitted_ Total amount committed to users in the merkle tree
     /// @return oldRoot The previous merkle root
+    /// @dev Enforces: committed amount never exceeds totalRewards, never decreases across
+    ///      updates, and the root is immutable once the campaign is finalized
     function setMerkleRoot(bytes32 root, uint256 totalCommitted_)
         external
         onlyTimeBasedIncentiveManager
         returns (bytes32 oldRoot)
     {
+        if (finalized) revert CampaignAlreadyFinalized();
+        if (totalCommitted_ > totalRewards) revert CommitmentExceedsBudget();
+        if (totalCommitted_ < totalCommitted) revert CommitmentDecreased();
+
         oldRoot = merkleRoot;
         merkleRoot = root;
         totalCommitted = totalCommitted_;

--- a/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
+++ b/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
@@ -231,6 +231,9 @@ contract TimeBasedIncentiveCampaign is Initializable, IClaw {
         if (cumulativeAmount <= alreadyClaimed) revert NothingToClaim();
         amount = cumulativeAmount - alreadyClaimed;
 
+        // The declared commitment is a hard ceiling on outflow
+        if (totalClaimed + amount > totalCommitted) revert ClaimExceedsCommitment();
+
         claimed[user] = cumulativeAmount;
         totalClaimed += amount;
 

--- a/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
+++ b/packages/evm/contracts/timebased/TimeBasedIncentiveCampaign.sol
@@ -112,6 +112,18 @@ contract TimeBasedIncentiveCampaign is Initializable, IClaw {
     /// @notice Error when campaign has not been finalized
     error CampaignNotFinalized();
 
+    /// @notice Error when a root commits more than the campaign's total rewards
+    error CommitmentExceedsBudget();
+
+    /// @notice Error when a root decreases the committed amount
+    error CommitmentDecreased();
+
+    /// @notice Error when updating the root after finalization
+    error CampaignAlreadyFinalized();
+
+    /// @notice Error when cumulative claims would exceed the committed amount
+    error ClaimExceedsCommitment();
+
     /// @notice Disable initialization on the implementation contract
     constructor() {
         _disableInitializers();

--- a/packages/evm/contracts/timebased/TimeBasedIncentiveManager.sol
+++ b/packages/evm/contracts/timebased/TimeBasedIncentiveManager.sol
@@ -454,7 +454,7 @@ contract TimeBasedIncentiveManager is Initializable, UUPSUpgradeable, Ownable {
     }
 
     /// @notice Update the merkle root for a campaign
-    /// @dev Roots can still be updated after finalization for emergency corrections
+    /// @dev Roots are immutable once the campaign is finalized
     /// @param campaignId The campaign ID
     /// @param root The new merkle root
     /// @param totalCommitted Total amount committed to users in the merkle tree

--- a/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
+++ b/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
@@ -881,9 +881,10 @@ contract TimeBasedIncentiveManagerTest is Test {
 
         // Build batch
         TimeBasedIncentiveManager.RootUpdate[] memory updates = new TimeBasedIncentiveManager.RootUpdate[](3);
+        // 3 ether gross funding => 2.7 ether net after 10% fee; commitments must stay within net
         updates[0] = TimeBasedIncentiveManager.RootUpdate(id1, keccak256("root1"), 1 ether, false);
         updates[1] = TimeBasedIncentiveManager.RootUpdate(id2, keccak256("root2"), 2 ether, false);
-        updates[2] = TimeBasedIncentiveManager.RootUpdate(id3, keccak256("root3"), 3 ether, false);
+        updates[2] = TimeBasedIncentiveManager.RootUpdate(id3, keccak256("root3"), 2.5 ether, false);
 
         manager.updateRootsBatch(updates);
 
@@ -893,7 +894,7 @@ contract TimeBasedIncentiveManagerTest is Test {
         assertEq(TimeBasedIncentiveCampaign(manager.getCampaign(id2)).merkleRoot(), keccak256("root2"));
         assertEq(TimeBasedIncentiveCampaign(manager.getCampaign(id2)).totalCommitted(), 2 ether);
         assertEq(TimeBasedIncentiveCampaign(manager.getCampaign(id3)).merkleRoot(), keccak256("root3"));
-        assertEq(TimeBasedIncentiveCampaign(manager.getCampaign(id3)).totalCommitted(), 3 ether);
+        assertEq(TimeBasedIncentiveCampaign(manager.getCampaign(id3)).totalCommitted(), 2.5 ether);
     }
 
     function test_UpdateRootsBatch_SingleItem() public {

--- a/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
+++ b/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
@@ -3544,14 +3544,17 @@ contract TimeBasedIncentiveManagerTest is Test {
         assertTrue(campaign.finalized(), "Should finalize when totalCommitted == totalRewards exactly");
     }
 
-    function test_EarlyFinalization_ExceedsCommitted() public {
+    function test_EarlyFinalization_AtExactBudget() public {
         (uint256 campaignId, TimeBasedIncentiveCampaign campaign) = _createCampaignWithRoot();
         uint256 netRewards = campaign.totalRewards();
 
-        // totalCommitted > totalRewards (edge case — dust rounding up)
+        // Committing past totalRewards is impossible (even dust rounding must stay within budget)
+        vm.expectRevert(TimeBasedIncentiveCampaign.CommitmentExceedsBudget.selector);
         manager.updateRoot(campaignId, keccak256("final"), netRewards + 1, true);
 
-        assertTrue(campaign.finalized(), "Should finalize when totalCommitted > totalRewards");
+        // Exhausting the budget exactly still allows early finalization
+        manager.updateRoot(campaignId, keccak256("final"), netRewards, true);
+        assertTrue(campaign.finalized(), "Should finalize when totalCommitted == totalRewards");
     }
 
     function test_EarlyFinalization_UsersCanStillClaim() public {

--- a/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
+++ b/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
@@ -3323,37 +3323,31 @@ contract TimeBasedIncentiveManagerTest is Test {
         manager.updateRoot(campaignId, keccak256("root"), 1 ether, true);
     }
 
-    function test_Finalization_NoDoubleEmit() public {
-        (uint256 campaignId, TimeBasedIncentiveCampaign campaign) = _createCampaignWithRoot();
-
-        vm.warp(campaign.endTime() + 1);
-        manager.updateRoot(campaignId, keccak256("root1"), 1 ether, true);
-
-        // Second finalize=true should not emit again
-        vm.recordLogs();
-        manager.updateRoot(campaignId, keccak256("root2"), 2 ether, true);
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-
-        // Should only have RootUpdated, not CampaignFinalized
-        for (uint256 i; i < logs.length; ++i) {
-            assertTrue(
-                logs[i].topics[0] != TimeBasedIncentiveManager.CampaignFinalized.selector,
-                "Should not emit CampaignFinalized twice"
-            );
-        }
-    }
-
-    function test_Finalization_CanUpdateRootAfterFinalize() public {
+    function test_Finalization_SecondFinalizeReverts() public {
         (uint256 campaignId, TimeBasedIncentiveCampaign campaign) = _createCampaignWithRoot();
 
         vm.warp(campaign.endTime() + 1);
         manager.updateRoot(campaignId, keccak256("root1"), 1 ether, true);
         assertTrue(campaign.finalized());
 
-        // Operator can still update root after finalization
+        // Any further updateRoot (finalize or not) reverts — no double finalize, no double emit
+        vm.expectRevert(TimeBasedIncentiveCampaign.CampaignAlreadyFinalized.selector);
+        manager.updateRoot(campaignId, keccak256("root2"), 2 ether, true);
+    }
+
+    function test_Finalization_RevertUpdateRootAfterFinalize() public {
+        (uint256 campaignId, TimeBasedIncentiveCampaign campaign) = _createCampaignWithRoot();
+
+        vm.warp(campaign.endTime() + 1);
+        manager.updateRoot(campaignId, keccak256("root1"), 1 ether, true);
+        assertTrue(campaign.finalized());
+
+        // The root is immutable after finalization
+        vm.expectRevert(TimeBasedIncentiveCampaign.CampaignAlreadyFinalized.selector);
         manager.updateRoot(campaignId, keccak256("root2"), 2 ether, false);
-        assertEq(campaign.merkleRoot(), keccak256("root2"), "Root should be updated");
-        assertEq(campaign.totalCommitted(), 2 ether, "Total committed should be updated");
+
+        assertEq(campaign.merkleRoot(), keccak256("root1"), "Root should be unchanged");
+        assertEq(campaign.totalCommitted(), 1 ether, "Total committed should be unchanged");
         assertTrue(campaign.finalized(), "Should still be finalized");
     }
 

--- a/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
+++ b/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
@@ -2198,7 +2198,7 @@ contract TimeBasedIncentiveManagerTest is Test {
         assertEq(rewardToken.balanceOf(address(campaign)), totalCommitted, "Campaign should retain owed funds");
     }
 
-    function test_WithdrawToBudget_EdgeCase_TotalClaimedExceedsTotalCommitted() public {
+    function test_UpdateRoot_RevertCommitmentDecreased() public {
         // Create a campaign
         (uint256 campaignId, TimeBasedIncentiveCampaign campaign) = _createCampaignWithRoot();
 
@@ -2208,23 +2208,23 @@ contract TimeBasedIncentiveManagerTest is Test {
         manager.updateRoot(campaignId, leaf1, 3 ether, false);
         manager.claim(campaignId, CLAIMER, 3 ether, proof);
 
-        // Now publish a corrected root with lower total (simulates ban or correction)
-        // totalCommitted drops to 1 ether, but user already claimed 3 ether
+        // A "correction" root that lowers totalCommitted can no longer be published,
+        // so totalClaimed > totalCommitted is unreachable by construction
         bytes32 leaf2 = _makeLeaf(address(0xDEAD), address(rewardToken), 1 ether);
+        vm.expectRevert(TimeBasedIncentiveCampaign.CommitmentDecreased.selector);
         manager.updateRoot(campaignId, leaf2, 1 ether, false);
 
-        // totalClaimed (3 ether) > totalCommitted (1 ether)
-        assertEq(campaign.totalClaimed(), 3 ether, "Total claimed should be 3 ether");
-        assertEq(campaign.totalCommitted(), 1 ether, "Total committed should be 1 ether");
+        // Re-publishing at the SAME committed amount is allowed (equal, not decreasing)
+        manager.updateRoot(campaignId, leaf2, 3 ether, false);
+        assertEq(campaign.totalCommitted(), 3 ether, "Total committed unchanged");
 
-        // Warp past end time and finalize
+        // Finalize and withdraw the remainder: balance 6 (9 - 3 claimed), nothing still owed
         vm.warp(campaign.endTime() + 1);
-        manager.updateRoot(campaignId, leaf2, 1 ether, true);
+        manager.updateRoot(campaignId, leaf2, 3 ether, true);
 
         uint256 balance = rewardToken.balanceOf(address(campaign));
         uint256 budgetBalanceBefore = rewardToken.balanceOf(address(budget));
 
-        // Should be able to withdraw full balance since nothing more is owed
         vm.prank(CREATOR);
         manager.withdraw(campaignId);
 

--- a/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
+++ b/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
@@ -1610,24 +1610,56 @@ contract TimeBasedIncentiveManagerTest is Test {
         assertEq(rewardToken.balanceOf(CLAIMER), actualAmount, "Balance should not change");
     }
 
-    function test_Claim_RevertWhenCampaignBalanceInsufficient() public {
+    function test_UpdateRoot_RevertCommitmentExceedsBudget() public {
         // Create a campaign with 9 ether (after 10% fee on 10 ether)
         (uint256 campaignId, TimeBasedIncentiveCampaign campaign) = _createCampaignWithRoot();
-        uint256 campaignBalance = rewardToken.balanceOf(address(campaign));
-        assertEq(campaignBalance, 9 ether, "Campaign should have 9 ether after fee");
+        uint256 netRewards = campaign.totalRewards();
+        assertEq(netRewards, 9 ether, "Campaign should have 9 ether after fee");
 
-        // Create a proof for more than the campaign balance
-        uint256 excessiveAmount = 20 ether;
-        bytes32 leaf = _makeLeaf(CLAIMER, address(rewardToken), excessiveAmount);
-        bytes32 root = leaf;
+        // A root committing more than totalRewards can no longer be published at all
+        vm.expectRevert(TimeBasedIncentiveCampaign.CommitmentExceedsBudget.selector);
+        manager.updateRoot(campaignId, keccak256("excessive"), netRewards + 1, false);
+
+        // Committing exactly totalRewards is fine
+        manager.updateRoot(campaignId, keccak256("exact"), netRewards, false);
+        assertEq(campaign.totalCommitted(), netRewards);
+    }
+
+    function test_Claim_RevertClaimExceedsCommitment() public {
+        // A tree whose leaves exceed the declared totalCommitted cannot pay out past it
+        (uint256 campaignId,) = _createCampaignWithRoot();
+
+        uint256 leafAmount = 2 ether;
+        bytes32 leaf = _makeLeaf(CLAIMER, address(rewardToken), leafAmount);
         bytes32[] memory proof = new bytes32[](0);
 
-        manager.updateRoot(campaignId, root, excessiveAmount, false);
+        // Declared commitment understates the leaf
+        manager.updateRoot(campaignId, leaf, 1 ether, false);
 
-        // Claim should revert due to insufficient balance in campaign
-        // SafeTransferLib will revert with TransferFailed
-        vm.expectRevert();
-        manager.claim(campaignId, CLAIMER, excessiveAmount, proof);
+        vm.expectRevert(TimeBasedIncentiveCampaign.ClaimExceedsCommitment.selector);
+        manager.claim(campaignId, CLAIMER, leafAmount, proof);
+    }
+
+    function test_Claim_RevertClaimExceedsCommitment_MultiUser() public {
+        // Two leaves summing past the declared total: first claim fits, second hits the ceiling
+        (uint256 campaignId,) = _createCampaignWithRoot();
+
+        bytes32 leaf1 = _makeLeaf(CLAIMER, address(rewardToken), 3 ether);
+        bytes32 leaf2 = _makeLeaf(CLAIMER2, address(rewardToken), 2 ether);
+        bytes32 root =
+            leaf1 < leaf2 ? keccak256(abi.encodePacked(leaf1, leaf2)) : keccak256(abi.encodePacked(leaf2, leaf1));
+        bytes32[] memory proof1 = new bytes32[](1);
+        proof1[0] = leaf2;
+        bytes32[] memory proof2 = new bytes32[](1);
+        proof2[0] = leaf1;
+
+        // Leaves sum to 5 ether but only 4 is declared
+        manager.updateRoot(campaignId, root, 4 ether, false);
+
+        manager.claim(campaignId, CLAIMER, 3 ether, proof1);
+
+        vm.expectRevert(TimeBasedIncentiveCampaign.ClaimExceedsCommitment.selector);
+        manager.claim(campaignId, CLAIMER2, 2 ether, proof2);
     }
 
     function test_Claim_CrossCampaignProofReuseFails() public {

--- a/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
+++ b/packages/evm/test/timebased/TimeBasedIncentiveManager.t.sol
@@ -1551,11 +1551,12 @@ contract TimeBasedIncentiveManagerTest is Test {
 
         // Second: try to use an old proof with lower cumulative (1 ether)
         // This simulates someone trying to use a stale/old proof
+        // (totalCommitted stays at 2 ether — it can never decrease)
         uint256 oldCumulative = 1 ether;
         bytes32 oldLeaf = _makeLeaf(CLAIMER, address(rewardToken), oldCumulative);
         bytes32 oldRoot = oldLeaf;
 
-        manager.updateRoot(campaignId, oldRoot, oldCumulative, false);
+        manager.updateRoot(campaignId, oldRoot, firstCumulative, false);
 
         // Should revert because oldCumulative (1 ether) <= alreadyClaimed (2 ether)
         vm.expectRevert(TimeBasedIncentiveCampaign.NothingToClaim.selector);


### PR DESCRIPTION
## Overview
Adds strict validation of merkle root commitments to prevent budget overruns and ensure campaign integrity. Once finalized, roots become immutable to eliminate emergency correction scenarios and simplify the contract's security model.

## Problem Addressed
Previously, the contract allowed:
- Committed amounts to exceed the campaign's total rewards budget
- Commitments to decrease across root updates, creating inconsistent state
- Root updates after finalization, bypassing intended campaign closure
- Claims to exceed declared commitments despite merkle proofs

These gaps created scenarios where outflows could theoretically exceed the declared budget or finalized campaigns could be modified, compromising the contract's guarantees.

## Changes Made

### New Validation Rules
- **Commitment Budget**: Declared commitments cannot exceed `totalRewards`, preventing over-subscription
- **Monotonic Commitments**: Commitments can only increase or stay equal, never decrease
- **Immutable Finalization**: Once a campaign is finalized, the root becomes immutable—no further updates allowed
- **Claim Ceiling**: Claims are capped at the declared `totalCommitted`, treating it as a hard ceiling regardless of merkle proofs

### Implementation Details
- Introduces four new error types: `CommitmentExceedsBudget`, `CommitmentDecreased`, `CampaignAlreadyFinalized`, and `ClaimExceedsCommitment`
- Validates constraints in `setMerkleRoot` before updating state
- Enforces claim ceiling in claim processing to catch mismatches between tree structure and declared commitment
- Updates documentation to reflect root immutability after finalization

### Test Coverage
- Validates commitment budget enforcement at root update time
- Verifies commitment monotonicity across updates
- Confirms root immutability prevents post-finalization modifications
- Tests claim ceiling enforcement in single and multi-user scenarios
- Ensures early finalization respects budget constraints
- Fixes existing tests to comply with new constraints (e.g., batch updates, stale proof scenarios)

## Benefits
- **Budget Safety**: Commitments act as a hard, enforceable ceiling on outflows
- **Predictability**: Campaign state becomes monotonic and deterministic
- **Simplified Semantics**: Finalization is now a one-way gate, eliminating complex emergency correction logic
- **Defense in Depth**: Claim validation provides a second line of defense against tree/commitment mismatches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened campaign accounting to prevent claims from exceeding approved commitments.
  * Prevented commitment updates from going above the reward budget or being reduced after publication.
  * Locked finalized campaigns so no further reward root updates can be made.

* **Tests**
  * Updated coverage for budget limits, claim ceilings, and finalization behavior.
  * Added checks for exact-budget finalization and multi-user claim limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->