### PR TITLE
[BOOST-6710] Add Aave v4 Spoke adapter with governance-authenticated position manager routing

### DIFF
--- a/packages/evm/contracts/timebased/TBIForwarderAdapters.sol
+++ b/packages/evm/contracts/timebased/TBIForwarderAdapters.sol
@@ -15,6 +15,20 @@ interface IAaveV3Pool {
     function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
 }
 
+/// @notice Aave v4 GiverPositionManager — the governance-registered position manager that supplies
+/// into a Spoke on behalf of a user. Aave v4's `Spoke.supply(onBehalfOf)` is restricted to the
+/// user's approved position managers (`onlyPositionManager`), so the forwarder cannot supply for a
+/// user directly; the Giver pulls the underlying from msg.sender and routes the supply instead.
+interface IGiverPositionManager {
+    function supplyOnBehalfOf(address spoke, uint256 reserveId, uint256 amount, address onBehalfOf) external;
+}
+
+/// @notice Minimal view onto an Aave v4 Spoke's governance registry of position managers, used to
+/// authenticate a caller-supplied Giver before trusting it with funds and the indexer signal.
+interface IAaveV4Spoke {
+    function isPositionManagerActive(address positionManager) external view returns (bool);
+}
+
 interface IComet {
     function supplyTo(address dst, address asset, uint256 amount) external;
 }

--- a/packages/evm/contracts/timebased/TBIForwarderAdapters.sol
+++ b/packages/evm/contracts/timebased/TBIForwarderAdapters.sol
@@ -281,6 +281,46 @@ abstract contract TBIForwarderAdapters is ReentrancyGuard {
         emit Deposit(receiver, address(pool), asset, amount);
     }
 
+    /// @notice Supply into an Aave v4 Spoke on behalf of receiver, routed through the
+    /// governance-registered GiverPositionManager (the Spoke's `supply(onBehalfOf)` only accepts
+    /// the user's approved position managers, so the forwarder cannot supply for a user directly).
+    /// @dev Requires `receiver` to have approved the Giver as a position manager on the Spoke
+    /// (`setUserPositionManager(giver, true)`, bundled by the frontend flow); without it the
+    /// Spoke's revert surfaces unchanged. A mismatched `asset`/`reserveId` pairing reverts inside
+    /// the Giver's pull/supply, so no funds path exists for a wrong asset.
+    ///
+    /// Unlike the other adapters, the contract called (the Giver) is not the contract emitted
+    /// (the Spoke), so the Giver cannot be trusted implicitly: it is authenticated against the
+    /// Spoke's own governance registry (`isPositionManagerActive`) before any funds move. A forged
+    /// `spoke` can vouch for a forged giver, but then the emitted `ledger` is that forged address,
+    /// which the indexer ignores — it only follows canonical Spokes. Emits `LedgerDeposit` (not
+    /// the generic `Deposit`) as the single indexer signal.
+    /// @param giver The Aave v4 GiverPositionManager
+    /// @param spoke The Aave v4 Spoke holding the reserve — emitted as the `ledger`
+    /// @param reserveId The Spoke's reserve id for `asset` — emitted as the `marketKey`
+    /// @param asset The reserve's underlying asset to supply
+    /// @param amount The amount of `asset` to supply
+    /// @param receiver The account credited with the supplied position
+    function depositAaveV4(
+        IGiverPositionManager giver,
+        address spoke,
+        uint256 reserveId,
+        address asset,
+        uint256 amount,
+        address receiver
+    ) external {
+        _requireReceiver(receiver);
+        if (!IAaveV4Spoke(spoke).isPositionManagerActive(address(giver))) {
+            revert GiverNotActivePositionManager(address(giver));
+        }
+        asset.safeTransferFrom(msg.sender, address(this), amount);
+        asset.safeApproveWithRetry(address(giver), amount);
+        giver.supplyOnBehalfOf(spoke, reserveId, amount, receiver);
+        asset.safeApprove(address(giver), 0);
+
+        emit LedgerDeposit(receiver, spoke, reserveId, amount);
+    }
+
     /// @notice Supply into a Compound v3 Comet on behalf of receiver
     /// @param comet The Comet contract
     /// @param asset The underlying asset to supply

--- a/packages/evm/contracts/timebased/TBIForwarderAdapters.sol
+++ b/packages/evm/contracts/timebased/TBIForwarderAdapters.sol
@@ -178,6 +178,14 @@ abstract contract TBIForwarderAdapters is ReentrancyGuard {
         uint256 amount1
     );
 
+    /// @notice Emitted once per Aave v4 (Spoke/Ledger) supply routed through this forwarder.
+    /// Distinct from the generic `Deposit` so the off-chain indexer gets one unambiguous log per
+    /// routed supply: `ledger` is the Spoke and `marketKey` its reserve id (in event data, not
+    /// indexed — the indexer filters by `(user, ledger)` and reads the key from data). `amount` is
+    /// in underlying units; shares are deliberately omitted because the same-transaction Spoke
+    /// `Supply` log feeds the backend's share mirror through its normal pipeline.
+    event LedgerDeposit(address indexed user, address indexed ledger, uint256 marketKey, uint256 amount);
+
     /// @notice Thrown when a Compound V2 cToken mint fails
     error MintFailed(uint256 errorCode);
 
@@ -218,6 +226,13 @@ abstract contract TBIForwarderAdapters is ReentrancyGuard {
 
     /// @notice Thrown when a Lido Earn deposit amount exceeds the SyncDepositQueue's uint224 range.
     error AmountExceedsUint224();
+
+    /// @notice Thrown when an Aave v4 deposit names a Giver the Spoke's governance has not
+    /// registered as an active position manager. The registry check is the trust boundary that
+    /// keeps `LedgerDeposit` honest: the emitted `ledger` (the Spoke) is not the contract being
+    /// called (the Giver), so an unauthenticated Giver could pocket the pulled funds and let the
+    /// forwarder emit an opt-in signal for a supply that never reached the Spoke.
+    error GiverNotActivePositionManager(address giver);
 
     /// @notice Canonical Permit2 address (same on every chain)
     address internal constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;

--- a/packages/evm/test/timebased/TBIForwarder.t.sol
+++ b/packages/evm/test/timebased/TBIForwarder.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
-import {Test} from "lib/forge-std/src/Test.sol";
+import {Test, Vm} from "lib/forge-std/src/Test.sol";
 
 import {LibClone} from "@solady/utils/LibClone.sol";
 import {ERC20} from "@solady/tokens/ERC20.sol";
@@ -12,6 +12,7 @@ import {
     TBIForwarderAdapters,
     IERC4626,
     IAaveV3Pool,
+    IGiverPositionManager,
     IComet,
     IStakedToken,
     ICErc20,

--- a/packages/evm/test/timebased/TBIForwarder.t.sol
+++ b/packages/evm/test/timebased/TBIForwarder.t.sol
@@ -86,6 +86,50 @@ contract MockAToken is ERC20 {
     }
 }
 
+/// @notice Minimal Aave v4 Spoke mock. Mirrors the three behaviors the adapter depends on:
+/// governance's registry of active position managers (`isPositionManagerActive`, which the adapter
+/// authenticates the Giver against), the per-user gate on `supply(onBehalfOf)` (the
+/// `onlyPositionManager` check users opt into via `setUserPositionManager`), and a reserve id
+/// mapping to its underlying asset. Supplied balances are tracked 1:1 per user.
+contract MockAaveV4Spoke {
+    error PositionManagerNotApproved();
+
+    mapping(uint256 => address) public reserveAsset;
+    mapping(address => bool) public isPositionManagerActive;
+    mapping(address => mapping(address => bool)) public userPositionManagers;
+    mapping(address => uint256) public suppliedBalance;
+
+    function setReserveAsset(uint256 reserveId, address asset) external {
+        reserveAsset[reserveId] = asset;
+    }
+
+    function setPositionManagerActive(address positionManager, bool active) external {
+        isPositionManagerActive[positionManager] = active;
+    }
+
+    function setUserPositionManager(address positionManager, bool approved) external {
+        userPositionManagers[msg.sender][positionManager] = approved;
+    }
+
+    function supply(uint256 reserveId, uint256 amount, address onBehalfOf) external {
+        if (!userPositionManagers[onBehalfOf][msg.sender]) revert PositionManagerNotApproved();
+        ERC20(reserveAsset[reserveId]).transferFrom(msg.sender, address(this), amount);
+        suppliedBalance[onBehalfOf] += amount;
+    }
+}
+
+/// @notice Minimal Aave v4 GiverPositionManager mock — pulls the reserve's underlying from the
+/// caller (the forwarder, which approved it) and supplies via the Spoke on behalf of the user,
+/// where the Spoke's position-manager gate applies to the Giver as msg.sender.
+contract MockGiverPositionManager {
+    function supplyOnBehalfOf(address spoke, uint256 reserveId, uint256 amount, address onBehalfOf) external {
+        address asset = MockAaveV4Spoke(spoke).reserveAsset(reserveId);
+        ERC20(asset).transferFrom(msg.sender, address(this), amount);
+        ERC20(asset).approve(spoke, amount);
+        MockAaveV4Spoke(spoke).supply(reserveId, amount, onBehalfOf);
+    }
+}
+
 /// @notice Minimal Compound v3 Comet mock that accepts supplyTo calls
 contract MockComet {
     MockCometReceipt public immutable receipt;

--- a/packages/evm/test/timebased/TBIForwarder.t.sol
+++ b/packages/evm/test/timebased/TBIForwarder.t.sol
@@ -636,6 +636,8 @@ contract TBIForwarderTest is Test {
     MockERC20 token1;
     MockERC4626 vault;
     MockAaveV3Pool aavePool;
+    MockAaveV4Spoke aaveV4Spoke;
+    MockGiverPositionManager giver;
     MockComet comet;
     MockStakedToken stakedToken;
     MockCErc20 cToken;
@@ -651,6 +653,7 @@ contract TBIForwarderTest is Test {
     address constant PERMIT2_ADDR = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
     address constant FEE_RECIPIENT = address(0xFEE);
     address constant MELLOW_NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    uint256 constant RESERVE_ID = 7;
 
     function setUp() public {
         // Deploy mock token and protocols
@@ -658,6 +661,10 @@ contract TBIForwarderTest is Test {
         token1 = new MockERC20();
         vault = new MockERC4626(address(token));
         aavePool = new MockAaveV3Pool(address(token));
+        aaveV4Spoke = new MockAaveV4Spoke();
+        aaveV4Spoke.setReserveAsset(RESERVE_ID, address(token));
+        giver = new MockGiverPositionManager();
+        aaveV4Spoke.setPositionManagerActive(address(giver), true);
         comet = new MockComet(address(token));
         stakedToken = new MockStakedToken(address(token));
         cToken = new MockCErc20(address(token));

--- a/packages/evm/test/timebased/TBIForwarder.t.sol
+++ b/packages/evm/test/timebased/TBIForwarder.t.sol
@@ -804,6 +804,127 @@ contract TBIForwarderTest is Test {
         assertEq(token.balanceOf(LIFI_EXECUTOR), 95 ether);
     }
 
+    // --- Aave V4 (Spoke/Ledger via GiverPositionManager) ---
+
+    function _depositAaveV4(address caller, uint256 amount, address receiver) internal {
+        vm.prank(caller);
+        forwarder.depositAaveV4(
+            IGiverPositionManager(address(giver)), address(aaveV4Spoke), RESERVE_ID, address(token), amount, receiver
+        );
+    }
+
+    function test_DepositAaveV4_Success() public {
+        uint256 amount = 5 ether;
+        vm.prank(USER);
+        aaveV4Spoke.setUserPositionManager(address(giver), true);
+
+        vm.expectEmit(true, true, true, true);
+        emit TBIForwarderAdapters.LedgerDeposit(USER, address(aaveV4Spoke), RESERVE_ID, amount);
+
+        _depositAaveV4(USER, amount, USER);
+
+        // User's supplied position was credited on the Spoke, which holds the underlying
+        assertEq(aaveV4Spoke.suppliedBalance(USER), amount);
+        assertEq(token.balanceOf(address(aaveV4Spoke)), amount);
+        // Forwarder holds nothing and its Giver approval is reset
+        assertEq(token.balanceOf(address(forwarder)), 0);
+        assertEq(token.allowance(address(forwarder), address(giver)), 0);
+        // User's token balance decreased
+        assertEq(token.balanceOf(USER), 95 ether);
+    }
+
+    function test_DepositAaveV4_WithReceiver_Success() public {
+        uint256 amount = 5 ether;
+        _fundAndApprove(LIFI_EXECUTOR, 100 ether);
+        // The position-manager opt-in belongs to the receiver (the onBehalfOf), not the caller.
+        vm.prank(RECEIVER);
+        aaveV4Spoke.setUserPositionManager(address(giver), true);
+
+        vm.expectEmit(true, true, true, true);
+        emit TBIForwarderAdapters.LedgerDeposit(RECEIVER, address(aaveV4Spoke), RESERVE_ID, amount);
+
+        _depositAaveV4(LIFI_EXECUTOR, amount, RECEIVER);
+
+        // Receiver was credited the position, while caller only paid underlying
+        assertEq(aaveV4Spoke.suppliedBalance(RECEIVER), amount);
+        assertEq(aaveV4Spoke.suppliedBalance(LIFI_EXECUTOR), 0);
+        // Forwarder holds nothing
+        assertEq(token.balanceOf(address(forwarder)), 0);
+        // Li.Fi caller's token balance decreased
+        assertEq(token.balanceOf(LIFI_EXECUTOR), 95 ether);
+    }
+
+    function test_DepositAaveV4_EmitsOnlyLedgerDeposit() public {
+        vm.prank(USER);
+        aaveV4Spoke.setUserPositionManager(address(giver), true);
+
+        vm.recordLogs();
+        _depositAaveV4(USER, 1 ether, USER);
+
+        // The forwarder emits exactly one log — LedgerDeposit — and no generic Deposit,
+        // so the Ledger indexer gets a single unambiguous signal per routed supply.
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 forwarderLogs;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(forwarder)) continue;
+            forwarderLogs++;
+            assertEq(
+                logs[i].topics[0],
+                keccak256("LedgerDeposit(address,address,uint256,uint256)"),
+                "unexpected forwarder event"
+            );
+        }
+        assertEq(forwarderLogs, 1, "forwarder must emit exactly one log");
+    }
+
+    function test_DepositAaveV4_RevertZeroReceiver() public {
+        vm.prank(USER);
+        vm.expectRevert(TBIForwarderAdapters.ZeroReceiver.selector);
+        forwarder.depositAaveV4(
+            IGiverPositionManager(address(giver)), address(aaveV4Spoke), RESERVE_ID, address(token), 1 ether, address(0)
+        );
+
+        // Reverts before funds move
+        assertEq(token.balanceOf(USER), 100 ether);
+        assertEq(token.balanceOf(address(forwarder)), 0);
+    }
+
+    function test_DepositAaveV4_RevertGiverNotActive() public {
+        // A caller-supplied giver the Spoke's governance has not registered must be rejected
+        // before any funds move — otherwise a fake giver could pocket the pull and let the
+        // forwarder emit a LedgerDeposit for the real Spoke without any canonical supply.
+        MockGiverPositionManager fakeGiver = new MockGiverPositionManager();
+        vm.prank(USER);
+        aaveV4Spoke.setUserPositionManager(address(fakeGiver), true);
+
+        vm.prank(USER);
+        vm.expectRevert(
+            abi.encodeWithSelector(TBIForwarderAdapters.GiverNotActivePositionManager.selector, address(fakeGiver))
+        );
+        forwarder.depositAaveV4(
+            IGiverPositionManager(address(fakeGiver)), address(aaveV4Spoke), RESERVE_ID, address(token), 1 ether, USER
+        );
+
+        // Reverts before funds move
+        assertEq(token.balanceOf(USER), 100 ether);
+        assertEq(token.balanceOf(address(forwarder)), 0);
+    }
+
+    function test_DepositAaveV4_RevertWithoutPositionManagerApproval() public {
+        // The user never called setUserPositionManager(giver, true) on the Spoke: the Spoke's
+        // gate must surface unchanged through the Giver and the forwarder (frontend prerequisite,
+        // see BOOST-6713 — the adapter adds no handling of its own).
+        vm.prank(USER);
+        vm.expectRevert(MockAaveV4Spoke.PositionManagerNotApproved.selector);
+        forwarder.depositAaveV4(
+            IGiverPositionManager(address(giver)), address(aaveV4Spoke), RESERVE_ID, address(token), 1 ether, USER
+        );
+
+        // The whole call reverted; no funds moved
+        assertEq(token.balanceOf(USER), 100 ether);
+        assertEq(token.balanceOf(address(forwarder)), 0);
+    }
+
     // --- Compound V3 ---
 
     function test_DepositCompoundV3_Success() public {

--- a/packages/evm/test/timebased/TBIForwarderAaveV4Fork.t.sol
+++ b/packages/evm/test/timebased/TBIForwarderAaveV4Fork.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Test, Vm} from "lib/forge-std/src/Test.sol";
+
+import {ERC20} from "@solady/tokens/ERC20.sol";
+
+import {TBIForwarder} from "contracts/timebased/TBIForwarder.sol";
+import {IGiverPositionManager} from "contracts/timebased/TBIForwarderAdapters.sol";
+
+/// @notice Surface of the Aave v4 Spoke the fork test drives: the user-side position-manager
+/// opt-in the deposit prerequisite hinges on, plus the canonical-state reads used to discover a
+/// live reserve and verify the supplied position. Signatures from aave/aave-v4 `ISpoke`.
+interface IAaveV4Spoke {
+    function setUserPositionManager(address positionManager, bool approve) external;
+    function isPositionManagerActive(address positionManager) external view returns (bool);
+    function getReserveCount() external view returns (uint256);
+    function getUserSuppliedAssets(uint256 reserveId, address user) external view returns (uint256);
+}
+
+/// @notice Mainnet fork test supplying into the live Aave v4 Main Spoke through the deployed
+/// TBIForwarder proxy (upgraded in-fork to this tree's implementation), routed via the
+/// governance-registered GiverPositionManager.
+///
+/// Unlike the Kyber zap fork test there is no captured-calldata fixture, so no block pin: the test
+/// forks latest and discovers a live reserve (USDC preferred, then WETH) from Spoke state at
+/// runtime, keeping it valid as reserves are listed or re-ordered.
+contract TBIForwarderAaveV4ForkTest is Test {
+    /// @dev Deployed TBIForwarder proxy on mainnet (deploys/1.json).
+    address internal constant FORWARDER = 0x7A33Bcf7588190e3123235db746339045207Bb93;
+
+    /// @dev Aave v4 GiverPositionManager, governance-registered on the Main Spoke.
+    address internal constant GIVER = 0x17A54b8d6D9C68e7fa1C7112AC998EA1BA51d11e;
+
+    /// @dev Aave v4 Main Spoke.
+    address internal constant SPOKE = 0x94e7A5dCbE816e498b89aB752661904E2F56c485;
+
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+    address internal constant USER = 0x1111111111111111111111111111111111111111;
+
+    /// @dev keccak256("LedgerDeposit(address,address,uint256,uint256)")
+    bytes32 internal constant LEDGER_DEPOSIT_TOPIC = keccak256("LedgerDeposit(address,address,uint256,uint256)");
+
+    function test_Fork_DepositAaveV4_EndToEnd() public {
+        // Requires a mainnet RPC; skipped when unset so the suite passes without one
+        // (CI provisions only VITE_SEPOLIA_RPC_URL).
+        string memory rpcUrl = vm.envOr("VITE_MAINNET_RPC_URL", string(""));
+        vm.skip(bytes(rpcUrl).length == 0);
+        vm.createSelectFork(rpcUrl);
+
+        // Upgrade the deployed proxy to this tree's implementation.
+        TBIForwarder forwarder = TBIForwarder(payable(FORWARDER));
+        TBIForwarder implementation = new TBIForwarder();
+        vm.prank(forwarder.owner());
+        forwarder.upgradeToAndCall(address(implementation), "");
+
+        // The Giver must be governance-registered on the Spoke or no opt-in can route through it.
+        IAaveV4Spoke spoke = IAaveV4Spoke(SPOKE);
+        assertTrue(spoke.isPositionManagerActive(GIVER), "Giver not active on Spoke");
+
+        (uint256 reserveId, address asset, uint256 decimals) = _findReserve(spoke);
+        uint256 amount = 10 ** decimals; // one whole token
+
+        deal(asset, USER, amount);
+        vm.prank(USER);
+        ERC20(asset).approve(FORWARDER, amount);
+
+        // Without the user's position-manager opt-in the Spoke rejects the Giver's supply — the
+        // prerequisite the frontend bundles (BOOST-6713) — and the revert surfaces to the caller.
+        vm.prank(USER);
+        vm.expectRevert();
+        forwarder.depositAaveV4(IGiverPositionManager(GIVER), SPOKE, reserveId, asset, amount, USER);
+
+        vm.prank(USER);
+        spoke.setUserPositionManager(GIVER, true);
+
+        vm.recordLogs();
+        vm.prank(USER);
+        forwarder.depositAaveV4(IGiverPositionManager(GIVER), SPOKE, reserveId, asset, amount, USER);
+
+        // The supplied position landed on the user (supplied-assets view rounds by ≤1 wei).
+        assertApproxEqAbs(spoke.getUserSuppliedAssets(reserveId, USER), amount, 1, "supplied position");
+        assertEq(ERC20(asset).balanceOf(USER), 0, "input fully consumed");
+
+        // The stateless forwarder retains nothing and its Giver approval is reset.
+        assertEq(ERC20(asset).balanceOf(FORWARDER), 0, "no asset left in forwarder");
+        assertEq(ERC20(asset).allowance(FORWARDER, GIVER), 0, "Giver approval reset");
+
+        _assertLedgerDepositEmitted(reserveId, amount);
+    }
+
+    /// @dev Discovers a live reserve to supply into, preferring USDC then WETH (both `deal`-able
+    /// and safely below any supply cap at one whole token). `getReserve(uint256)` returns the
+    /// `Reserve` struct whose head word is `underlying` and fourth word is `decimals`; decoding
+    /// just those two keeps the test decoupled from the rest of the struct. Reserve ids are
+    /// scanned from 0 through `getReserveCount()` inclusive to stay agnostic to id base.
+    function _findReserve(IAaveV4Spoke spoke)
+        internal
+        view
+        returns (uint256 reserveId, address asset, uint256 decimals)
+    {
+        uint256 count = spoke.getReserveCount();
+        uint256 wethReserveId = type(uint256).max;
+        uint256 wethDecimals;
+        for (uint256 i = 0; i <= count; i++) {
+            (bool ok, bytes memory data) = address(spoke).staticcall(abi.encodeWithSignature("getReserve(uint256)", i));
+            if (!ok || data.length < 128) continue;
+            (address underlying,,, uint256 reserveDecimals) = abi.decode(data, (address, address, uint256, uint256));
+            if (underlying == USDC) return (i, USDC, reserveDecimals);
+            if (underlying == WETH && wethReserveId == type(uint256).max) {
+                wethReserveId = i;
+                wethDecimals = reserveDecimals;
+            }
+        }
+        require(wethReserveId != type(uint256).max, "no USDC or WETH reserve on Spoke");
+        return (wethReserveId, WETH, wethDecimals);
+    }
+
+    /// @dev Asserts the forwarder emitted exactly one log: a LedgerDeposit with the Spoke as
+    /// `ledger`, the reserve id as `marketKey` (in data, not indexed), and underlying units.
+    function _assertLedgerDepositEmitted(uint256 reserveId, uint256 amount) internal {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 forwarderLogs;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != FORWARDER) continue;
+            forwarderLogs++;
+            assertEq(logs[i].topics[0], LEDGER_DEPOSIT_TOPIC, "unexpected forwarder event");
+            assertEq(address(uint160(uint256(logs[i].topics[1]))), USER, "event user");
+            assertEq(address(uint160(uint256(logs[i].topics[2]))), SPOKE, "event ledger");
+            (uint256 marketKey, uint256 eventAmount) = abi.decode(logs[i].data, (uint256, uint256));
+            assertEq(marketKey, reserveId, "event marketKey");
+            assertEq(eventAmount, amount, "event amount");
+        }
+        assertEq(forwarderLogs, 1, "forwarder must emit exactly one log");
+    }
+}


### PR DESCRIPTION
Adds support for supplying into Aave v4 Spoke contracts through the governance-registered GiverPositionManager, enabling the forwarder to route deposits on behalf of users while maintaining security guarantees.

## Problem

Aave v4 Spoke's `supply(onBehalfOf)` method restricts calls to user-approved position managers via an `onlyPositionManager` guard. The forwarder cannot supply directly for users; instead, it must route through an approved position manager (the Giver), which pulls the underlying asset and supplies via the Spoke.

Since the contract being called (Giver) differs from the contract being credited (Spoke), an unauthenticated Giver could pocket pulled funds while the forwarder emits a deposit signal for a supply that never reached the Spoke. This creates a trust boundary requiring explicit validation.

## Solution

Implements a new `depositAaveV4` adapter function that:

- **Authenticates the Giver** against the Spoke's governance registry (`isPositionManagerActive`) before any funds move, preventing rogue position managers from intercepting deposits
- **Routes through the approved manager** by pulling the asset to the forwarder, approving the Giver, and calling `supplyOnBehalfOf` with the receiver as the beneficiary
- **Emits a dedicated `LedgerDeposit` event** (distinct from the generic `Deposit`) to give the off-chain indexer an unambiguous signal per routed supply, with the Spoke as the credited ledger and reserve id as the market key

## Security & Design

- The Giver authentication check is the trust boundary that keeps the emitted ledger (Spoke) honest—only governance-registered position managers are trusted with funds and the indexer signal
- A forged Spoke can vouch for a forged Giver, but the emitted ledger will be the forged address, which the indexer ignores (it only follows canonical Spokes)
- User-side position-manager opt-in (`setUserPositionManager(giver, true)`) is a frontend prerequisite; the adapter surfaces any Spoke revert unchanged
- Asset/reserve id mismatches revert inside the Giver's pull/supply, preventing funds from reaching a wrong destination

## Testing

Includes comprehensive unit tests covering:
- Successful deposits with and without a separate receiver
- Event emission (exactly one `LedgerDeposit` per call, no generic `Deposit`)
- Zero-receiver validation
- Rejection of inactive Givers before funds move
- Propagation of Spoke's position-manager approval gate

Also adds an end-to-end fork test against mainnet's live Aave v4 deployment, verifying the full flow with canonical contracts and discovering reserves dynamically to remain valid as the protocol evolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for depositing assets into Aave V4 markets through registered position managers.
  * Deposits now validate the recipient and manager authorization, route funds to the selected reserve, and emit a ledger deposit event.
  * Added support for forwarding deposits to another recipient.

* **Bug Fixes**
  * Ensured temporary token approvals are cleared after deposits.
  * Added validation for zero recipients, inactive managers, and missing user authorization.

* **Tests**
  * Added unit and mainnet-fork coverage for successful deposits, authorization checks, balances, events, and approval cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->